### PR TITLE
DW-4048: Disable EMRFS + QA

### DIFF
--- a/emr/adg/cluster.yaml.tpl
+++ b/emr/adg/cluster.yaml.tpl
@@ -6,7 +6,7 @@ Applications:
 CustomAmiId: "${ami_id}"
 EbsRootVolumeSize: 100
 LogUri: "s3://${s3_log_bucket}/logs"
-Name: "emr-launcher-test"
+Name: "analytical-dataset-generator"
 ReleaseLabel: "emr-5.24.1"
 ScaleDownBehavior: "TERMINATE_AT_TASK_COMPLETION"
 ServiceRole: "${service_role}"

--- a/emr/adg/configurations.yaml.tpl
+++ b/emr/adg/configurations.yaml.tpl
@@ -39,13 +39,6 @@ Configurations:
   Properties:
     "hbase.emr.storageMode": "s3"
     "hbase.emr.readreplica.enabled": "true"
-- Classification: "emrfs-site"
-  Properties:
-    "fs.s3.consistent.retryPeriodSeconds": "3"
-    "fs.s3.consistent": "true"
-    "fs.s3.cse.materialsDescription.enabled": "true"
-    "fs.s3.consistent.retryCount": "5"
-    "fs.s3.consistent.metadata.tableName": "DataGen-metadata"
 - Classification: "spark-env"
   Configurations:
   - Classification: "export"

--- a/local.tf
+++ b/local.tf
@@ -56,7 +56,7 @@ locals {
 
   adg_emr_lambda_schedule = {
     development = "1 0 * * ? *"
-    qa          = "1 * * * ? *"
+    qa          = "0 0 31 12 ? 2025"
     integration = "0 0 31 12 ? 2025"
     preprod     = "0 0 31 12 ? 2025"
     production  = "0 0 31 12 ? 2025"

--- a/local.tf
+++ b/local.tf
@@ -55,7 +55,7 @@ locals {
   }
 
   adg_emr_lambda_schedule = {
-    development = "1 0 * * ? *"
+    development = "1 * * * ? *"
     qa          = "0 0 31 12 ? 2025"
     integration = "0 0 31 12 ? 2025"
     preprod     = "0 0 31 12 ? 2025"


### PR DESCRIPTION
AWS have advised that we don't need EMRFS configured at all for an HBase
read-replica.

In addition, because QA's ingest-hbase cluster is breaking, disable ADG in
that environment for now as it's blocking pipelines reaching production.