### PR TITLE
Delimit Spark no_proxy settings with pipes

### DIFF
--- a/cluster_config.tf
+++ b/cluster_config.tf
@@ -53,7 +53,7 @@ resource "aws_s3_bucket_object" "configurations" {
       s3_published_bucket = aws_s3_bucket.published.id
       s3_ingest_bucket    = data.terraform_remote_state.ingest.outputs.s3_buckets.input_bucket
       hbase_root_path     = local.hbase_root_path
-      proxy_no_proxy      = local.no_proxy
+      proxy_no_proxy      = replace(local.no_proxy, ",", "|")
       proxy_http_address  = data.terraform_remote_state.internet_egress.outputs.internet_proxy.dns_name
       proxy_https_address = data.terraform_remote_state.internet_egress.outputs.internet_proxy.dns_name
     }


### PR DESCRIPTION
Yes, really! Java uses a pipe-separated list, not a comma separated list.

https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html