### PR TITLE
Bypass proxy for all region-based S3 requests

### DIFF
--- a/local.tf
+++ b/local.tf
@@ -79,7 +79,7 @@ locals {
   }
 
   amazon_region_domain = "${data.aws_region.current.name}.amazonaws.com"
-  endpoint_services    = ["autoscaling", "dynamodb", "ec2", "ec2messages", "ecr.dkr", "glue", "kms", "logs", "monitoring", "s3", "secretsmanager", "sns", "sqs", "ssm", "ssmmessages"]
+  endpoint_services    = ["autoscaling", "dynamodb", "ec2", "ec2messages", "ecr.dkr", "glue", "kms", "logs", "monitoring", ".s3", "s3", "secretsmanager", "sns", "sqs", "ssm", "ssmmessages"]
   no_proxy             = "169.254.169.254,${join(",", formatlist("%s.%s", local.endpoint_services, local.amazon_region_domain))}"
 
   emrfs_em = {


### PR DESCRIPTION
PySpark is using virtual-host style requests for S3 access, so route all
requests to <bucket_name>.s3.<region>.amazonaws.com as well as
s3.<region>.amazonaws.com through the S3 endpoint, not the proxy.