### PR TITLE
Specify multiple subnets for the ADG cluster

### DIFF
--- a/cluster_config.tf
+++ b/cluster_config.tf
@@ -26,7 +26,7 @@ resource "aws_s3_bucket_object" "instances" {
       keep_cluster_alive = local.keep_cluster_alive[local.environment]
       add_master_sg      = aws_security_group.adg_common.id
       add_slave_sg       = aws_security_group.adg_common.id
-      subnet_id          = data.terraform_remote_state.internal_compute.outputs.htme_subnet.ids[0]
+      subnet_ids         = join(",", data.terraform_remote_state.internal_compute.outputs.htme_subnet.ids)
       master_sg          = aws_security_group.adg_master.id
       slave_sg           = aws_security_group.adg_slave.id
       service_access_sg  = aws_security_group.adg_emr_service.id

--- a/cluster_config/instances.yaml.tpl
+++ b/cluster_config/instances.yaml.tpl
@@ -5,7 +5,7 @@ Instances:
   - "${add_master_sg}"
   AdditionalSlaveSecurityGroups:
   - "${add_slave_sg}"
-  Ec2SubnetId: "${subnet_id}"
+  Ec2SubnetIds: ${jsonencode(split(",", subnet_ids))}
   EmrManagedMasterSecurityGroup: "${master_sg}"
   EmrManagedSlaveSecurityGroup: "${slave_sg}"
   ServiceAccessSecurityGroup: "${service_access_sg}"


### PR DESCRIPTION
When multiple EC2 subnet IDs are specified, Amazon EMR evaluates them and launches
instances in the optimal subnet. This will help ADG be robust against an AZ failure
at launch time.
(https://docs.aws.amazon.com/emr/latest/APIReference/API_JobFlowInstancesConfig.html#EMR-Type-JobFlowInstancesConfig-Ec2SubnetIds)