### PR TITLE
DW-4391 - Fixing proxy ref in emr-setup.sh script to be ECS rather than EC2 proxy

### DIFF
--- a/bootstrap_actions.tf
+++ b/bootstrap_actions.tf
@@ -9,7 +9,7 @@ resource "aws_s3_bucket_object" "emr_setup_sh" {
       S3_COMMON_LOGGING_SHELL         = format("s3://%s/%s", data.terraform_remote_state.common.outputs.config_bucket.id, data.terraform_remote_state.common.outputs.application_logging_common_file.s3_id)
       S3_LOGGING_SHELL                = format("s3://%s/%s", data.terraform_remote_state.common.outputs.config_bucket.id, aws_s3_bucket_object.logging_script.key)
       aws_default_region              = "eu-west-2"
-      full_proxy                      = data.terraform_remote_state.internet_egress.outputs.internet_proxy.http_address
+      full_proxy                      = data.terraform_remote_state.internet_egress.outputs.container_internet_proxy.http_address
       full_no_proxy                   = local.no_proxy
       acm_cert_arn                    = aws_acm_certificate.analytical-dataset-generator.arn
       private_key_alias               = "private_key"


### PR DESCRIPTION
Signed-off-by: Benjamin Sherwood <benjaminsherwood@digital.uc.dwp.gov.uk>