### PR TITLE
correcting policy attached to analytical_dataset_crown_read_only and adding non_pii policy

### DIFF
--- a/published_bucket.tf
+++ b/published_bucket.tf
@@ -285,5 +285,71 @@ data "aws_iam_policy_document" "analytical_dataset_crown_read_only" {
 resource "aws_iam_policy" "analytical_dataset_crown_read_only" {
   name        = "AnalyticalDatasetCrownReadOnly"
   description = "Allow read access to the Crown-specific subset of the Analytical Dataset"
-  policy      = data.aws_iam_policy_document.analytical_dataset_read_only.json
+  policy      = data.aws_iam_policy_document.analytical_dataset_crown_read_only.json
+}
+
+data "aws_iam_policy_document" "analytical_dataset_crown_read_only_non_pii" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      aws_s3_bucket.published.arn,
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    resources = [
+      aws_s3_bucket.published.arn,
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "s3:ExistingObjectTag/Pii"
+
+      values = [
+        "false"
+      ]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "s3:ExistingObjectTag/collection_tag"
+
+      values = [
+        "crown"
+      ]
+
+    }
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+    ]
+
+    resources = [
+      "${aws_kms_key.published_bucket_cmk.arn}",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "analytical_dataset_crown_read_only_non_pii" {
+  name        = "AnalyticalDatasetCrownReadOnlyNonPii"
+  description = "Allow read access to the Crown-specific subset of the Analytical Dataset"
+  policy      = data.aws_iam_policy_document.analytical_dataset_crown_read_only_non_pii.json
 }

--- a/variables.tf
+++ b/variables.tf
@@ -35,7 +35,7 @@ variable "emr_instance_type" {
   default = {
     development = "m5.8xlarge"
     qa          = "m5.2xlarge"
-    integration = "m5.8xlarge"  # temp increase for DW-4437 testing
+    integration = "m5.8xlarge" # temp increase for DW-4437 testing
     preprod     = "m5.2xlarge"
     production  = "m5.8xlarge"
   }


### PR DESCRIPTION
* The policy analytical_dataset_crown_read_only had been incorrectly linked to the analytical_dataset_read_only document meaning that it wasn't being restricted by the crown tag, as intended.

* There needs to be a policy to restrict access to PII data on the condition of another tag. I have set up a boolean tag as follows: `Pii: <value>`