### PR TITLE
Setting-adg-weighted-capacity

### DIFF
--- a/cluster_config.tf
+++ b/cluster_config.tf
@@ -31,7 +31,7 @@ resource "aws_s3_bucket_object" "instances" {
       slave_sg             = aws_security_group.adg_slave.id
       service_access_sg    = aws_security_group.adg_emr_service.id
       instance_type        = var.emr_instance_type[local.environment]
-      no_core_nodes        = var.emr_no_vcpus[local.environment]
+      no_vcpus             = var.emr_no_vcpus[local.environment]
       core_instance_type_1 = var.emr_core_instance_type_1[local.environment]
       core_instance_type_2 = var.emr_core_instance_type_2[local.environment]
       weightedcapacity_1   = var.emr_weightedcapacity_1[local.environment]

--- a/cluster_config.tf
+++ b/cluster_config.tf
@@ -31,7 +31,7 @@ resource "aws_s3_bucket_object" "instances" {
       slave_sg             = aws_security_group.adg_slave.id
       service_access_sg    = aws_security_group.adg_emr_service.id
       instance_type        = var.emr_instance_type[local.environment]
-      no_core_nodes        = var.emr_no_core_nodes[local.environment]
+      no_core_nodes        = var.emr_no_vcpus[local.environment]
       core_instance_type_1 = var.emr_core_instance_type_1[local.environment]
       core_instance_type_2 = var.emr_core_instance_type_2[local.environment]
       weightedcapacity_1   = var.emr_weightedcapacity_1[local.environment]

--- a/cluster_config.tf
+++ b/cluster_config.tf
@@ -23,15 +23,19 @@ resource "aws_s3_bucket_object" "instances" {
   key    = "emr/adg/instances.yaml"
   content = templatefile("${path.module}/cluster_config/instances.yaml.tpl",
     {
-      keep_cluster_alive = local.keep_cluster_alive[local.environment]
-      add_master_sg      = aws_security_group.adg_common.id
-      add_slave_sg       = aws_security_group.adg_common.id
-      subnet_ids         = join(",", data.terraform_remote_state.internal_compute.outputs.adg_subnet.ids)
-      master_sg          = aws_security_group.adg_master.id
-      slave_sg           = aws_security_group.adg_slave.id
-      service_access_sg  = aws_security_group.adg_emr_service.id
-      instance_type      = var.emr_instance_type[local.environment]
-      no_core_nodes      = var.emr_no_core_nodes[local.environment]
+      keep_cluster_alive   = local.keep_cluster_alive[local.environment]
+      add_master_sg        = aws_security_group.adg_common.id
+      add_slave_sg         = aws_security_group.adg_common.id
+      subnet_ids           = join(",", data.terraform_remote_state.internal_compute.outputs.adg_subnet.ids)
+      master_sg            = aws_security_group.adg_master.id
+      slave_sg             = aws_security_group.adg_slave.id
+      service_access_sg    = aws_security_group.adg_emr_service.id
+      instance_type        = var.emr_instance_type[local.environment]
+      no_core_nodes        = var.emr_no_core_nodes[local.environment]
+      core_instance_type_1 = var.emr_core_instance_type_1[local.environment]
+      core_instance_type_2 = var.emr_core_instance_type_2[local.environment]
+      weightedcapacity_1   = var.emr_weightedcapacity_1[local.environment]
+      weightedcapacity_2   = var.emr_weightedcapacity_2[local.environment]
     }
   )
 }

--- a/cluster_config/instances.yaml.tpl
+++ b/cluster_config/instances.yaml.tpl
@@ -23,7 +23,7 @@ Instances:
       InstanceType: "${instance_type}"
   - InstanceFleetType: "CORE"
     Name: CORE
-    TargetOnDemandCapacity: ${no_core_nodes}
+    TargetOnDemandCapacity: ${no_vcpus}
     InstanceTypeConfigs:
     - EbsConfiguration:
         EbsBlockDeviceConfigs:

--- a/cluster_config/instances.yaml.tpl
+++ b/cluster_config/instances.yaml.tpl
@@ -34,11 +34,11 @@ Instances:
       InstanceType: "${core_instance_type_1}"
       WeightedCapacity: ${weightedcapacity_1}
     InstanceTypeConfigs:
-          EbsConfiguration:
-            EbsBlockDeviceConfigs:
-            - VolumeSpecification:
-                SizeInGB: 250
-                VolumeType: "gp2"
-              VolumesPerInstance: 1
-          InstanceType: "${core_instance_type_2}"
-          WeightedCapacity : ${weightedcapacity_2}
+    - EbsConfiguration:
+        EbsBlockDeviceConfigs:
+        - VolumeSpecification:
+            SizeInGB: 250
+            VolumeType: "gp2"
+          VolumesPerInstance: 1
+      InstanceType: "${core_instance_type_2}"
+      WeightedCapacity : ${weightedcapacity_2}

--- a/cluster_config/instances.yaml.tpl
+++ b/cluster_config/instances.yaml.tpl
@@ -25,7 +25,7 @@ Instances:
     Name: CORE
     TargetOnDemandCapacity: ${no_core_nodes}
     InstanceTypeConfigs:
-      EbsConfiguration:
+    - EbsConfiguration:
         EbsBlockDeviceConfigs:
         - VolumeSpecification:
             SizeInGB: 250

--- a/cluster_config/instances.yaml.tpl
+++ b/cluster_config/instances.yaml.tpl
@@ -25,10 +25,20 @@ Instances:
     Name: CORE
     TargetOnDemandCapacity: ${no_core_nodes}
     InstanceTypeConfigs:
-    - EbsConfiguration:
+      EbsConfiguration:
         EbsBlockDeviceConfigs:
         - VolumeSpecification:
             SizeInGB: 250
             VolumeType: "gp2"
           VolumesPerInstance: 1
-      InstanceType: "${instance_type}"
+      InstanceType: "${core_instance_type_1}"
+      WeightedCapacity: ${weightedcapacity_1}
+    InstanceTypeConfigs:
+          EbsConfiguration:
+            EbsBlockDeviceConfigs:
+            - VolumeSpecification:
+                SizeInGB: 250
+                VolumeType: "gp2"
+              VolumesPerInstance: 1
+          InstanceType: "${core_instance_type_2}"
+          WeightedCapacity : ${weightedcapacity_2}

--- a/cluster_config/instances.yaml.tpl
+++ b/cluster_config/instances.yaml.tpl
@@ -41,4 +41,4 @@ Instances:
             VolumeType: "gp2"
           VolumesPerInstance: 1
       InstanceType: "${core_instance_type_2}"
-      WeightedCapacity : ${weightedcapacity_2}
+      WeightedCapacity: ${weightedcapacity_2}

--- a/variables.tf
+++ b/variables.tf
@@ -42,13 +42,13 @@ variable "emr_instance_type" {
   }
 }
 
-variable "emr_no_core_nodes" {
+variable "emr_no_vcpus" {
   default = {
-    development = "2"
-    qa          = "2"
-    integration = "2"
-    preprod     = "2"
-    production  = "20"
+    development = "64"
+    qa          = "16"
+    integration = "64"
+    preprod     = "16"
+    production  = "1920"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -42,13 +42,13 @@ variable "emr_instance_type" {
   }
 }
 
-variable "emr_no_core_nodes" {
+  variable "emr_no_core_nodes" {
   default = {
     development = "2"
     qa          = "2"
     integration = "2"
     preprod     = "2"
-    production  = "20"
+    production  = "12"
   }
 }
 
@@ -58,7 +58,7 @@ variable "emr_maxExecutors" {
     qa          = "20"
     integration = "20"
     preprod     = "20"
-    production  = "1900"
+    production  = "1100"
   }
 }
 
@@ -100,7 +100,7 @@ variable "emr_weightedcapacity_1" {
     qa          = "2"
     integration = "2"
     preprod     = "2"
-    production  = "20"
+    production  = "12"
   }
 }
 
@@ -110,7 +110,7 @@ variable "emr_weightedcapacity_2" {
     qa          = "2"
     integration = "2"
     preprod     = "2"
-    production  = "40"
+    production  = "24"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -113,10 +113,3 @@ variable "emr_weightedcapacity_2" {
     production  = "24"
   }
 }
-
-
-
-
-
-
-

--- a/variables.tf
+++ b/variables.tf
@@ -96,20 +96,20 @@ variable "emr_core_instance_type_2" {
 
 variable "emr_weightedcapacity_1" {
   default = {
-    development = "2"
-    qa          = "2"
-    integration = "2"
-    preprod     = "2"
-    production  = "20"
+    development = "32"
+    qa          = "8"
+    integration = "32"
+    preprod     = "8"
+    production  = "96"
   }
 }
 
 variable "emr_weightedcapacity_2" {
   default = {
-    development = "4"
-    qa          = "4"
-    integration = "4"
-    preprod     = "4"
-    production  = "40"
+    development = "16"
+    qa          = "8"
+    integration = "16"
+    preprod     = "8"
+    production  = "48"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -48,7 +48,7 @@ variable "emr_no_core_nodes" {
     qa          = "2"
     integration = "2"
     preprod     = "2"
-    production  = "12"
+    production  = "20"
   }
 }
 
@@ -58,7 +58,7 @@ variable "emr_maxExecutors" {
     qa          = "20"
     integration = "20"
     preprod     = "20"
-    production  = "1100"
+    production  = "1900"
   }
 }
 
@@ -85,9 +85,9 @@ variable "emr_core_instance_type_1" {
 
 variable "emr_core_instance_type_2" {
   default = {
-    development = "m5.8xlarge"
+    development = "m5.4xlarge"
     qa          = "m5.2xlarge"
-    integration = "m5.8xlarge"
+    integration = "m5.4xlarge"
     preprod     = "m5.2xlarge"
     production  = "m5.12xlarge"
   }
@@ -100,16 +100,16 @@ variable "emr_weightedcapacity_1" {
     qa          = "2"
     integration = "2"
     preprod     = "2"
-    production  = "12"
+    production  = "20"
   }
 }
 
 variable "emr_weightedcapacity_2" {
   default = {
-    development = "2"
-    qa          = "2"
-    integration = "2"
-    preprod     = "2"
-    production  = "24"
+    development = "4"
+    qa          = "4"
+    integration = "4"
+    preprod     = "4"
+    production  = "40"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -42,7 +42,7 @@ variable "emr_instance_type" {
   }
 }
 
-  variable "emr_no_core_nodes" {
+variable "emr_no_core_nodes" {
   default = {
     development = "2"
     qa          = "2"

--- a/variables.tf
+++ b/variables.tf
@@ -86,9 +86,9 @@ variable "emr_core_instance_type_1" {
 variable "emr_core_instance_type_2" {
   default = {
     development = "m5.4xlarge"
-    qa          = "m5.2xlarge"
+    qa          = "m5.xlarge"
     integration = "m5.4xlarge"
-    preprod     = "m5.2xlarge"
+    preprod     = "m5.xlarge"
     production  = "m5.12xlarge"
   }
 }
@@ -107,9 +107,9 @@ variable "emr_weightedcapacity_1" {
 variable "emr_weightedcapacity_2" {
   default = {
     development = "16"
-    qa          = "8"
+    qa          = "4"
     integration = "16"
-    preprod     = "8"
+    preprod     = "4"
     production  = "48"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -71,3 +71,52 @@ variable "emr_minExecutors" {
     production  = "100"
   }
 }
+
+variable "emr_core_instance_type_1" {
+  default = {
+    development = "m5.8xlarge"
+    qa          = "m5.2xlarge"
+    integration = "m5.8xlarge"
+    preprod     = "m5.2xlarge"
+    production  = "m5.24xlarge"
+  }
+}
+
+
+variable "emr_core_instance_type_2" {
+  default = {
+    development = "m5.8xlarge"
+    qa          = "m5.2xlarge"
+    integration = "m5.8xlarge"
+    preprod     = "m5.2xlarge"
+    production  = "m5.12xlarge"
+  }
+}
+
+
+variable "emr_weightedcapacity_1" {
+  default = {
+    development = "2"
+    qa          = "2"
+    integration = "2"
+    preprod     = "2"
+    production  = "20"
+  }
+}
+
+variable "emr_weightedcapacity_2" {
+  default = {
+    development = "2"
+    qa          = "2"
+    integration = "2"
+    preprod     = "2"
+    production  = "40"
+  }
+}
+
+
+
+
+
+
+


### PR DESCRIPTION
Setting the ADG instances to use  weighted capacity in case where the instances are not provisioned by AWS ( Throws ""Provisioning for instance fleet timed out" error)