### PR TITLE
Reduce prod scale

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -48,7 +48,7 @@ variable "emr_no_vcpus" {
     qa          = "16"
     integration = "64"
     preprod     = "16"
-    production  = "1920"
+    production  = "1248"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -58,7 +58,7 @@ variable "emr_maxExecutors" {
     qa          = "20"
     integration = "20"
     preprod     = "20"
-    production  = "1900"
+    production  = "250"
   }
 }
 


### PR DESCRIPTION
This scales prod down so that it'll create a maximum of 26x m5.12xlarge instances,
which will entirely consume a /27 subnet (/27 = 32 IPs, -5 for internal AWS use, -1 for EMR service use).