### PR TITLE
Upgrade to EMR-5.29.0 and use the Kyro Serializer

### DIFF
--- a/cluster_config.tf
+++ b/cluster_config.tf
@@ -14,6 +14,7 @@ resource "aws_s3_bucket_object" "cluster" {
       service_role           = aws_iam_role.adg_emr_service.arn
       instance_profile       = aws_iam_instance_profile.analytical_dataset_generator.arn
       security_configuration = aws_emr_security_configuration.ebs_emrfs_em.id
+      emr_release            = var.emr_release[local.environment]
     }
   )
 }

--- a/cluster_config/cluster.yaml.tpl
+++ b/cluster_config/cluster.yaml.tpl
@@ -7,7 +7,7 @@ CustomAmiId: "${ami_id}"
 EbsRootVolumeSize: 100
 LogUri: "s3://${s3_log_bucket}/${s3_log_prefix}"
 Name: "analytical-dataset-generator"
-ReleaseLabel: "emr-5.24.1"
+ReleaseLabel: "emr-${emr_release}"
 SecurityConfiguration: "${security_configuration}"
 ScaleDownBehavior: "TERMINATE_AT_TASK_COMPLETION"
 ServiceRole: "${service_role}"

--- a/cluster_config/configurations.yaml.tpl
+++ b/cluster_config/configurations.yaml.tpl
@@ -26,6 +26,7 @@ Configurations:
     "spark.driver.cores": "${spark_driver_cores}"
     "spark.executor.instances": "${spark_executor_instances}"
     "spark.default.parallelism": "${spark_default_parallelism}"
+    "spark.serializer": "org.apache.spark.serializer.KryoSerializer"
 
 - Classification: "spark-hive-site"
   Properties:

--- a/variables.tf
+++ b/variables.tf
@@ -40,6 +40,16 @@ variable "analytical_dataset_generation_exporter_jar" {
   }
 }
 
+variable "emr_release" {
+  default = {
+    development = "5.29.0"
+    qa          = "5.29.0"
+    integration = "5.29.0"
+    preprod     = "5.29.0"
+    production  = "5.29.0"
+  }
+}
+
 variable "emr_instance_type" {
   default = {
     development = "m5.8xlarge"


### PR DESCRIPTION
We are hitting memory issues when serializing larger collections, so try using the Kyro serializer instead. From https://aws.amazon.com/blogs/big-data/best-practices-for-successfully-managing-memory-for-apache-spark-applications-on-amazon-emr/