### PR TITLE
[DW-4712] Add permission to read from performance metrics data folder in s3

### DIFF
--- a/published_bucket.tf
+++ b/published_bucket.tf
@@ -312,6 +312,7 @@ data "aws_iam_policy_document" "analytical_dataset_crown_read_only_non_pii" {
 
     resources = [
       "${aws_s3_bucket.published.arn}/analytical-dataset/*",
+      "${aws_s3_bucket.published.arn}/aws-analytical-env-metrics-data/*"
     ]
 
     condition {


### PR DESCRIPTION
* The Analytical Environment requires permission to read files from the aws-analytical-env-metrics-data folder in the published bucket - this is where we are storing standardised dummy data for performance measuring.