### PR TITLE
changing and adding new SG rules for lambda

### DIFF
--- a/ci/meta.yml
+++ b/ci/meta.yml
@@ -60,7 +60,7 @@ meta:
               jq -n --arg Username "$USERNAME" --arg Paramname "$PARAM_NAME" '{mysql_user_username: $Username, mysql_user_password_secret_name: $Paramname}' > manifest.json
               echo "Manifest is:"
               cat manifest.json
-              aws lambda invoke --function-name manage-mysql-user --invocation-type RequestResponse --payload file://manifest.json --cli-connect-timeout 600 --cli-read-timeout 600 output.json
+              aws lambda invoke --function-name manage-hive-metastore-mysql-users --invocation-type RequestResponse --payload file://manifest.json --cli-connect-timeout 600 --cli-read-timeout 600 output.json
               cat output.json | jq -eC "if .errorMessage? then error(.errorMessage) else true end"
 
     rotate-adg-reader-password:
@@ -81,6 +81,12 @@ meta:
         params:
           USERNAME: "pdm-writer"
           PARAM_NAME: "metadata-store-pdm-writer"
+    rotate-master-password:
+      .: (( inject meta.plan.rotate-mysql-password ))
+      config:
+        params:
+          USERNAME: "hive"
+          PARAM_NAME: "metadata-store-hive"
     terraform-apply:
       task: terraform-apply
       .: (( inject meta.plan.terraform-common-config ))

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -53,7 +53,7 @@ resource "aws_security_group_rule" "egress_aurora_lambda" {
   source_security_group_id = aws_security_group.hive_metastore.id
 }
 
-resource "aws_security_group_rule" "egress_aurora_https_to_vpc_endpoints" {
+resource "aws_security_group_rule" "egress_lambda_https_to_vpc_endpoints" {
   description              = "Allow HTTPS traffic to VPC endpoints"
   from_port                = 443
   protocol                 = "tcp"
@@ -63,8 +63,8 @@ resource "aws_security_group_rule" "egress_aurora_https_to_vpc_endpoints" {
   source_security_group_id = data.terraform_remote_state.internal_compute.outputs.vpc.vpc.interface_vpce_sg_id
 }
 
-resource "aws_security_group_rule" "ingress_aurora_https_vpc_endpoints_from_emr" {
-  description              = "Allow HTTPS traffic from hive metastore"
+resource "aws_security_group_rule" "ingress_lambda_https_vpc_endpoints_from_emr" {
+  description              = "Allow HTTPS traffic from rds password rotator lambda"
   from_port                = 443
   protocol                 = "tcp"
   security_group_id        = data.terraform_remote_state.internal_compute.outputs.vpc.vpc.interface_vpce_sg_id

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -35,22 +35,42 @@ resource "aws_security_group" "metastore_rds_user_lambda" {
 
 resource "aws_security_group_rule" "ingress_aurora_lambda" {
   description              = "Allow traffic to Aurora RDS from mysql manager lambda"
-  from_port                = 3306
+  from_port                = 443
   protocol                 = "tcp"
   security_group_id        = aws_security_group.hive_metastore.id
-  to_port                  = 3306
+  to_port                  = 443
   type                     = "ingress"
   source_security_group_id = aws_security_group.metastore_rds_user_lambda.id
 }
 
 resource "aws_security_group_rule" "egress_aurora_lambda" {
   description              = "Allow traffic to Aurora RDS from mysql manager lambda"
-  from_port                = 3306
+  from_port                = 443
   protocol                 = "tcp"
   security_group_id        = aws_security_group.metastore_rds_user_lambda.id
-  to_port                  = 3306
+  to_port                  = 443
   type                     = "egress"
   source_security_group_id = aws_security_group.hive_metastore.id
+}
+
+resource "aws_security_group_rule" "egress_aurora_https_to_vpc_endpoints" {
+  description              = "Allow HTTPS traffic to VPC endpoints"
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.metastore_rds_user_lambda.id
+  to_port                  = 443
+  type                     = "egress"
+  source_security_group_id = data.terraform_remote_state.internal_compute.outputs.vpc.vpc.interface_vpce_sg_id
+}
+
+resource "aws_security_group_rule" "ingress_aurora_https_vpc_endpoints_from_emr" {
+  description              = "Allow HTTPS traffic from hive metastore"
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = data.terraform_remote_state.internal_compute.outputs.vpc.vpc.interface_vpce_sg_id
+  to_port                  = 443
+  type                     = "ingress"
+  source_security_group_id = aws_security_group.metastore_rds_user_lambda.id
 }
 
 resource "aws_security_group_rule" "egress_https_to_vpc_endpoints" {

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -33,7 +33,7 @@ resource "aws_security_group" "metastore_rds_user_lambda" {
   vpc_id                 = data.terraform_remote_state.internal_compute.outputs.vpc.vpc.vpc.id
 }
 
-resource "aws_security_group_rule" "ingress_aurora_lambda" {
+resource "aws_security_group_rule" "ingress_aurora_lambda_https" {
   description              = "Allow traffic to Aurora RDS from mysql manager lambda"
   from_port                = 443
   protocol                 = "tcp"

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -43,7 +43,7 @@ resource "aws_security_group_rule" "ingress_aurora_lambda" {
   source_security_group_id = aws_security_group.metastore_rds_user_lambda.id
 }
 
-resource "aws_security_group_rule" "egress_aurora_lambda" {
+resource "aws_security_group_rule" "egress_aurora_lambda_https" {
   description              = "Allow traffic to Aurora RDS from mysql manager lambda"
   from_port                = 443
   protocol                 = "tcp"
@@ -51,6 +51,26 @@ resource "aws_security_group_rule" "egress_aurora_lambda" {
   to_port                  = 443
   type                     = "egress"
   source_security_group_id = aws_security_group.hive_metastore.id
+}
+
+resource "aws_security_group_rule" "egress_aurora_lambda_sql" {
+  description              = "Allow traffic to Aurora RDS from mysql manager lambda"
+  from_port                = 3306
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.metastore_rds_user_lambda.id
+  to_port                  = 3306
+  type                     = "egress"
+  source_security_group_id = aws_security_group.hive_metastore.id
+}
+
+resource "aws_security_group_rule" "ingress_aurora_lambda_sql" {
+  description              = "Allow traffic to Aurora RDS from mysql manager lambda"
+  from_port                = 3306
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.hive_metastore.id
+  to_port                  = 3306
+  type                     = "ingress"
+  source_security_group_id = aws_security_group.metastore_rds_user_lambda.id
 }
 
 resource "aws_security_group_rule" "egress_lambda_https_to_vpc_endpoints" {

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -33,26 +33,6 @@ resource "aws_security_group" "metastore_rds_user_lambda" {
   vpc_id                 = data.terraform_remote_state.internal_compute.outputs.vpc.vpc.vpc.id
 }
 
-resource "aws_security_group_rule" "ingress_aurora_lambda_https" {
-  description              = "Allow traffic to Aurora RDS from mysql manager lambda"
-  from_port                = 443
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.hive_metastore.id
-  to_port                  = 443
-  type                     = "ingress"
-  source_security_group_id = aws_security_group.metastore_rds_user_lambda.id
-}
-
-resource "aws_security_group_rule" "egress_aurora_lambda_https" {
-  description              = "Allow traffic to Aurora RDS from mysql manager lambda"
-  from_port                = 443
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.metastore_rds_user_lambda.id
-  to_port                  = 443
-  type                     = "egress"
-  source_security_group_id = aws_security_group.hive_metastore.id
-}
-
 resource "aws_security_group_rule" "egress_aurora_lambda_sql" {
   description              = "Allow traffic to Aurora RDS from mysql manager lambda"
   from_port                = 3306


### PR DESCRIPTION
The lambda needs to communicate to RDS via port 443 not 3306 as this is a HTTPS request and not a mysql command. 

The lambda also needs access to vpc endpoints where RDS lives. 

I was also calling the lambda with the wrong name previously. 