### PR TITLE
change root ca as previous one was for a serverless implementation

### DIFF
--- a/ci/groups.yml
+++ b/ci/groups.yml
@@ -40,7 +40,6 @@ groups:
       - rotate-mysql-password-adg-reader-qa
       - rotate-mysql-password-adg-reader-integration
       - rotate-mysql-password-adg-reader-preprod
-      - rotate-mysql-password-adg-reader-production
   - name: rotate-passwords-adg-writer
     jobs:
       - rotate-mysql-password-adg-writer-development

--- a/ci/jobs/rotate-mysql-password-adg-reader.yml
+++ b/ci/jobs/rotate-mysql-password-adg-reader.yml
@@ -31,10 +31,3 @@ jobs:
             AWS_ACC: ((aws_account.preprod))
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.preprod)):role/ci
 
-  - name: rotate-mysql-password-adg-reader-production
-    plan:
-      - .: (( inject meta.plan.rotate-adg-reader-password ))
-        config:
-          params:
-            AWS_ACC: ((aws_account.production))
-            AWS_ROLE_ARN: arn:aws:iam::((aws_account.production)):role/ci

--- a/lambda_manage_mysql_user.tf
+++ b/lambda_manage_mysql_user.tf
@@ -90,7 +90,7 @@ resource "aws_lambda_function" "manage_mysql_user" {
       RDS_DATABASE_NAME               = aws_rds_cluster.hive_metastore.database_name
       RDS_MASTER_USERNAME             = var.metadata_store_master_username
       RDS_MASTER_PASSWORD_SECRET_NAME = aws_secretsmanager_secret.metadata_store_master.name
-      RDS_CA_CERT                     = "/var/task/AmazonRootCA1.pem" # For Aurora serverless
+      RDS_CA_CERT                     = "/var/task/rds-ca-2019-2015-root.pem"
       LOG_LEVEL                       = "DEBUG"
     }
   }


### PR DESCRIPTION
the previous root-ca was for a Serverless implementation. this one is necessary for the currently deployed RDS Aurora instance. 

also, removed adg-reader user from production environment. This user is not required and is only available currently for testing out what adg wrote into the database. Therefore there is no reason for it to go to prod. 