### PR TITLE
Make Hive database backend configurable per env

### DIFF
--- a/cluster_config.tf
+++ b/cluster_config.tf
@@ -96,6 +96,7 @@ resource "aws_s3_bucket_object" "configurations" {
       hive_metastore_pwd                  = jsondecode(data.aws_secretsmanager_secret_version.rds_aurora_secrets.secret_string)["password"]
       hive_metastore_endpoint             = aws_rds_cluster.hive_metastore.endpoint
       hive_metastore_database_name        = aws_rds_cluster.hive_metastore.database_name
+      hive_metastore_backend              = local.hive_metastore_backend[local.environment]
     }
   )
 }

--- a/cluster_config/configurations.yaml.tpl
+++ b/cluster_config/configurations.yaml.tpl
@@ -39,7 +39,21 @@ Configurations:
     "hbase.scan.cache": "1000000"
     "hbase.scan.cacheblock": "false"
     "hbase.scan.batch": "2"
+    %{~ if hive_metastore_backend == "glue" ~}
     "hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory"
+    %{~ endif ~}
+    %{~ if hive_metastore_backend == "aurora" ~}
+    "hive.txn.manager": "org.apache.hadoop.hive.ql.lockmgr.DbTxnManager"
+    "hive.enforce.bucketing": "true"
+    "hive.exec.dynamic.partition.mode": "nostrict"
+    "hive.compactor.initiator.on": "true"
+    "hive.compactor.worker.threads": "1"
+    "hive.support.concurrency": "true"
+    "javax.jdo.option.ConnectionURL": "jdbc:mysql://${hive_metastore_endpoint}:3306/${hive_metastore_database_name}?createDatabaseIfNotExist=true"
+    "javax.jdo.option.ConnectionDriverName": "org.mariadb.jdbc.Driver"
+    "javax.jdo.option.ConnectionUserName": "${hive_metsatore_username}"
+    "javax.jdo.option.ConnectionPassword": "${hive_metastore_pwd}"
+    %{~ endif ~}
 
 - Classification: "hive-site"
   Properties:
@@ -48,7 +62,21 @@ Configurations:
     "hbase.client.scanner.timeout.period": "1200000"
     "hbase.rpc.timeout": "1800000"
     "hbase.client.operation.timeout": "3600000"
+    %{~ if hive_metastore_backend == "glue" ~}
     "hive.metastore.client.factory.class": "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory"
+    %{~ endif ~}
+    %{~ if hive_metastore_backend == "aurora" ~}
+    "hive.txn.manager": "org.apache.hadoop.hive.ql.lockmgr.DbTxnManager"
+    "hive.enforce.bucketing": "true"
+    "hive.exec.dynamic.partition.mode": "nostrict"
+    "hive.compactor.initiator.on": "true"
+    "hive.compactor.worker.threads": "1"
+    "hive.support.concurrency": "true"
+    "javax.jdo.option.ConnectionURL": "jdbc:mysql://${hive_metastore_endpoint}:3306/${hive_metastore_database_name}?createDatabaseIfNotExist=true"
+    "javax.jdo.option.ConnectionDriverName": "org.mariadb.jdbc.Driver"
+    "javax.jdo.option.ConnectionUserName": "${hive_metsatore_username}"
+    "javax.jdo.option.ConnectionPassword": "${hive_metastore_pwd}"
+    %{~ endif ~}
 - Classification: "emrfs-site"
   Properties:
     "fs.s3.consistent": "true"

--- a/local.tf
+++ b/local.tf
@@ -134,4 +134,12 @@ locals {
   }
 
   published_db = "analytical_dataset_generation"
+
+  hive_metastore_backend = {
+    development = "aurora"
+    qa          = "glue"
+    integration = "glue"
+    preprod     = "glue"
+    production  = "glue"
+  }
 }


### PR DESCRIPTION
This allows each environment to choose whether or not to
use Aurora or Glue as the metastore backend to support seamless
migrations.