### PR TITLE
WIP: Package logger module up

### DIFF
--- a/cluster_config/steps.yaml.tpl
+++ b/cluster_config/steps.yaml.tpl
@@ -33,5 +33,7 @@ Steps:
     - "yarn"
     - "--conf"
     - "spark.yarn.submit.waitAppCompletion=true"
+    - "--py-files"
+    - "/opt/emr/steps.zip"
     Jar: "command-runner.jar"
   ActionOnFailure: "CONTINUE"

--- a/steps/hive-setup.sh
+++ b/steps/hive-setup.sh
@@ -7,8 +7,11 @@ source /opt/emr/logging.sh
 function log_wrapper_message() {
     log_adg_message "$1" "hive-setup.sh" "$$" "Running as: $USER"
 }
-aws s3 cp "${python_logger}" /opt/emr/.
-aws s3 cp "${generate_analytical_dataset}" /opt/emr/.
+mkdir /opt/emr/steps
+aws s3 cp "${python_logger}" /opt/emr/steps
+touch /opt/emr/steps/__init__.py
+cd /opt/emr && zip -r steps.zip steps
+aws s3 cp "${generate_analytical_dataset}" /opt/emr
 ) >> /var/log/adg/nohup.log 2>&1
 
 


### PR DESCRIPTION
This fixes this error:

```
Traceback (most recent call last):
  File "/opt/emr/generate_dataset_from_htme.py", line 19, in <module>
    from steps.logger import setup_logging
ModuleNotFoundError: No module named 'steps'
```

But now results in this error:

```
Exception: It appears that you are attempting to reference SparkContext from a broadcast variable, action, or transformation. SparkContext can only be used on the driver, not in code that it run on workers. For more information, see SPARK-5063.
```

Help very much needed and appreciated by someone/anyone that knows what they're doing please!