### PR TITLE
Revert EMR launcher Lambda release that breaks production

### DIFF
--- a/ci/jobs/production/analytical-dataset-generation-production.yml
+++ b/ci/jobs/production/analytical-dataset-generation-production.yml
@@ -19,7 +19,7 @@ jobs:
       trigger: true
       passed:
       - analytical-dataset-generation-preprod
-      version: { tag: 0.0.8 }
+      version: { tag: 0.0.13 }
     - get: analytical-dataset-generation-exporter-release
       trigger: true
       passed:

--- a/ci/jobs/production/analytical-dataset-generation-production.yml
+++ b/ci/jobs/production/analytical-dataset-generation-production.yml
@@ -19,6 +19,7 @@ jobs:
       trigger: true
       passed:
       - analytical-dataset-generation-preprod
+      version: { tag: 0.0.8 }
     - get: analytical-dataset-generation-exporter-release
       trigger: true
       passed:


### PR DESCRIPTION
None of our infra is ready to work with the new version of the
Lambda, so pin it back to a previous version for now.