### PR TITLE
DW-5094: Hive Metastore CloudWatch Logs and Insights

### DIFF
--- a/local.tf
+++ b/local.tf
@@ -152,4 +152,12 @@ locals {
     preprod     = "aurora"
     production  = "aurora"
   }
+
+  hive_metastore_monitoring_interval = {
+    development = 0
+    qa          = 0
+    integration = 0
+    preprod     = 0
+    production  = 0
+  }
 }

--- a/metastore.tf
+++ b/metastore.tf
@@ -128,30 +128,6 @@ resource "aws_rds_cluster_parameter_group" "hive_metastore_logs" {
   }
 }
 
-data "aws_iam_policy_document" "rds_em_assume_role" {
-  statement {
-    sid     = "RDSEMAssumeRole"
-    effect  = "Allow"
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      identifiers = ["monitoring.rds.amazonaws.com"]
-      type        = "Service"
-    }
-  }
-}
-
-resource "aws_iam_role" "rds_enhanced_monitoring" {
-  name               = "rds_enhanced_monitoring"
-  assume_role_policy = data.aws_iam_policy_document.rds_em_assume_role.json
-  tags               = local.common_tags
-}
-
-resource "aws_iam_role_policy_attachment" "rds_enhanced_monitoring" {
-  role       = aws_iam_role.rds_enhanced_monitoring.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
-}
-
 resource "random_id" "password_salt" {
   byte_length = 16
 }
@@ -191,7 +167,7 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
   performance_insights_enabled    = true
   performance_insights_kms_key_id = aws_kms_key.hive_metastore_perf_insights.arn
   monitoring_interval             = local.hive_metastore_monitoring_interval[local.environment]
-  monitoring_role_arn             = aws_iam_role.rds_enhanced_monitoring.arn
+  monitoring_role_arn             = data.terraform_remote_state.common.outputs.rds_enhanced_monitoring_role.arn
   apply_immediately               = true
 }
 


### PR DESCRIPTION
This adds support for shipping MySQL logs from the Hive Metastore
cluster to CloudWatch. It also enables Peformance Insights so we
can get visibility of potential performance issues.

Finally, it adds supporting infra to enable Enhanced Monitoring
should the above tools hint that it would provide value. As we
don't yet know whether it's valuable, or at what frequency we should
collect metrics, it's simply disabled for now, but easily enabled
on a per-env basis.