### PR TITLE
DW-5094: Allow Performance Insights to be configurable per env

### DIFF
--- a/local.tf
+++ b/local.tf
@@ -132,7 +132,7 @@ locals {
     qa          = "db.t3.medium"
     integration = "db.t3.medium"
     preprod     = "db.t3.medium"
-    production  = "db.t3.medium"
+    production  = "db.r5.large"
   }
 
   hive_metastore_instance_count = {
@@ -159,5 +159,13 @@ locals {
     integration = 0
     preprod     = 0
     production  = 0
+  }
+
+   hive_metastore_enable_perf_insights = {
+    development = false
+    qa          = false
+    integration = false
+    preprod     = false
+    production  = true
   }
 }

--- a/metastore.tf
+++ b/metastore.tf
@@ -143,8 +143,8 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
   db_subnet_group_name            = aws_rds_cluster.hive_metastore.db_subnet_group_name
   tags                            = merge(local.common_tags, { Name = "hive-metastore" })
   engine                          = aws_rds_cluster.hive_metastore.engine
-  performance_insights_enabled    = true
-  performance_insights_kms_key_id = aws_kms_key.hive_metastore_perf_insights.arn
+  performance_insights_enabled    = local.hive_metastore_enable_perf_insights[local.environment]
+  performance_insights_kms_key_id = local.hive_metastore_enable_perf_insights[local.environment] ? aws_kms_key.hive_metastore_perf_insights.arn : ""
   apply_immediately               = true
 }
 


### PR DESCRIPTION
Performance Insights can't be enabled on T-Class instances (see
https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.Overview.html#USER_PerfInsights.Overview.Engines).

So, make Perf Insights configurable per environment and only enable
in Production for now.