### PR TITLE
DW-5904: Remove log_output parameter

### DIFF
--- a/metastore.tf
+++ b/metastore.tf
@@ -92,11 +92,6 @@ resource "aws_rds_cluster_parameter_group" "hive_metastore_logs" {
   description = "Logging parameters for Hive Metastore"
 
   parameter {
-    name  = "log_output"
-    value = "FILE"
-  }
-
-  parameter {
     name  = "general_log"
     value = "1"
   }


### PR DESCRIPTION
The `log_output` parameter is set to FILE by default and specifying it
explicitly causes Terraform to detect a perpetual diff in configs.