### PR TITLE
DW-5904: Enable performance insights in QA

### DIFF
--- a/local.tf
+++ b/local.tf
@@ -129,7 +129,7 @@ locals {
   published_bucket_non_pii_prefix = "runmetadata"
   hive_metastore_instance_type = {
     development = "db.t3.medium"
-    qa          = "db.t3.medium"
+    qa          = "db.r5.large"
     integration = "db.t3.medium"
     preprod     = "db.t3.medium"
     production  = "db.r5.large"
@@ -161,9 +161,9 @@ locals {
     production  = 0
   }
 
-   hive_metastore_enable_perf_insights = {
+  hive_metastore_enable_perf_insights = {
     development = false
-    qa          = false
+    qa          = true
     integration = false
     preprod     = false
     production  = true

--- a/metastore.tf
+++ b/metastore.tf
@@ -141,7 +141,7 @@ resource "aws_rds_cluster" "hive_metastore" {
   vpc_security_group_ids          = [aws_security_group.hive_metastore.id]
   storage_encrypted               = true
   kms_key_id                      = aws_kms_key.hive_metastore.arn
-  enabled_cloudwatch_logs_exports = ["audit", "general", "slowquery"]
+  enabled_cloudwatch_logs_exports = ["audit", "error", "general", "slowquery"]
   db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.hive_metastore_logs.name
   apply_immediately               = true
   tags                            = merge(local.common_tags, { Name = "hive-metastore" })


### PR DESCRIPTION
This ensures we have at least one other env with the
same config as prod.

Also, export the error logs to CloudWatch. The docs say that they're
exported by default, but if you choose to export some non-default logs
then that overrides *that* default so they end up *not* being exported.