### PR TITLE
DW-5281: Compress ADG output

### DIFF
--- a/steps/generate_dataset_from_htme.py
+++ b/steps/generate_dataset_from_htme.py
@@ -386,7 +386,7 @@ def decompress(compressed_text):
 
 
 def persist_json(json_location, values):
-    values.saveAsTextFile(json_location)
+    values.saveAsTextFile(json_location, compressionCodecClass="com.hadoop.compression.lzo.LzopCodec")
 
 
 def get_collection(collection_name):


### PR DESCRIPTION
This is done with the aims of:
1. Reducing S3 spend by compressing the 17TB of ADG data (prod)
2. Speeding up PDM by not having to perform I/O on 17TB of ADG data