### PR TITLE
Use the latest python repo due to incoming breaking e2e change needin…

### DIFF
--- a/ci/meta.yml
+++ b/ci/meta.yml
@@ -303,8 +303,7 @@ meta:
           type: docker-image
           source:
             repository: ((dataworks.docker_python_boto_behave_repository))
-            version: 0.0.26
-            tag: 0.0.26
+            tag: ((dataworks.docker_python_boto_behave_version))
         run:
           dir: aws-dataworks-e2e-framework
           path: sh

--- a/ci/meta.yml
+++ b/ci/meta.yml
@@ -297,8 +297,8 @@ meta:
           type: docker-image
           source:
             repository: ((dataworks.docker_python_boto_behave_repository))
-            version: 0.0.24
-            tag: 0.0.24
+            version: 0.0.26
+            tag: 0.0.26
         run:
           dir: aws-dataworks-e2e-framework
           path: sh


### PR DESCRIPTION
Use the latest python repo due to incoming breaking e2e change needing this version