### PR TITLE
byuc-271_Add new mysql user for kickstart adg process

### DIFF
--- a/ci/groups.yml
+++ b/ci/groups.yml
@@ -75,3 +75,10 @@ groups:
       - rotate-mysql-password-bgdc-reader-integration
       - rotate-mysql-password-bgdc-reader-preprod
       - rotate-mysql-password-bgdc-reader-production
+  - name: rotate-passwords-kickstart-adg-writer
+      jobs:
+        - rotate-mysql-password-kickstart-adg-writer-development
+        - rotate-mysql-password-kickstart-adg-writer-qa
+        - rotate-mysql-password-kickstart-adg-writer-integration
+        - rotate-mysql-password-kickstart-adg-writer-preprod
+        - rotate-mysql-password-kickstart-adg-writer-production

--- a/ci/jobs/rotate-mysql-password-kickstart-adg.yml
+++ b/ci/jobs/rotate-mysql-password-kickstart-adg.yml
@@ -1,0 +1,40 @@
+jobs:
+  - name: rotate-mysql-password-kickstart-adg-writer-development
+    plan:
+      - .: (( inject meta.plan.rotate-kickstart-adg-writer-password ))
+        config:
+          params:
+            AWS_ACC: ((aws_account.development))
+            AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci
+
+  - name: rotate-mysql-password-kickstart-adg-writer-qa
+    plan:
+      - .: (( inject meta.plan.rotate-kickstart-adg-writer-password ))
+        config:
+          params:
+            AWS_ACC: ((aws_account.qa))
+            AWS_ROLE_ARN: arn:aws:iam::((aws_account.qa)):role/ci
+
+  - name: rotate-mysql-password-kickstart-adg-writer-integration
+    plan:
+      - .: (( inject meta.plan.rotate-kickstart-adg-writer-password ))
+        config:
+          params:
+            AWS_ACC: ((aws_account.integration))
+            AWS_ROLE_ARN: arn:aws:iam::((aws_account.integration)):role/ci
+
+  - name: rotate-mysql-password-kickstart-adg-writer-preprod
+    plan:
+      - .: (( inject meta.plan.rotate-kickstart-adg-writer-password ))
+        config:
+          params:
+            AWS_ACC: ((aws_account.preprod))
+            AWS_ROLE_ARN: arn:aws:iam::((aws_account.preprod)):role/ci
+
+  - name: rotate-mysql-password-kickstart-adg-writer-production
+    plan:
+      - .: (( inject meta.plan.rotate-kickstart-adg-writer-password ))
+        config:
+          params:
+            AWS_ACC: ((aws_account.production))
+            AWS_ROLE_ARN: arn:aws:iam::((aws_account.production)):role/ci

--- a/ci/meta.yml
+++ b/ci/meta.yml
@@ -123,6 +123,13 @@ meta:
           USERNAME: "bgdc-reader"
           PARAM_NAME: "metadata-store-bgdc-reader"
           PRIVILEGES: SELECT
+    rotate-kickstart-adg-writer-password:
+      .: (( inject meta.plan.rotate-mysql-password ))
+      config:
+        params:
+          USERNAME: "kickstart-adg-writer"
+          PARAM_NAME: "metadata-store-kickstart-adg-writer"
+          PRIVILEGES: ALL
     rotate-master-password:
       .: (( inject meta.plan.rotate-mysql-master-password ))
       config:

--- a/lambda_manage_mysql_user.tf
+++ b/lambda_manage_mysql_user.tf
@@ -55,6 +55,7 @@ data "aws_iam_policy_document" "manage_hive_metastore_mysql_users" {
       aws_secretsmanager_secret.metadata_store_pdm_writer.arn,
       aws_secretsmanager_secret.metadata_store_analytical_env.arn,
       aws_secretsmanager_secret.metadata_store_bgdc.arn,
+      aws_secretsmanager_secret.metadata_store_kickstart_adg.arn
     ]
   }
 }

--- a/metastore.tf
+++ b/metastore.tf
@@ -237,6 +237,12 @@ resource "aws_secretsmanager_secret" "metadata_store_bgdc" {
   tags        = local.common_tags
 }
 
+resource "aws_secretsmanager_secret" "metadata_store_kickstart_adg" {
+  name        = "metadata-store-${var.metadata_store_kickstart_username}"
+  description = "${var.metadata_store_kickstart_username} SQL user for Metadata Store"
+  tags        = local.common_tags
+}
+
 output "hive_metastore" {
   value = {
     security_group = aws_security_group.hive_metastore
@@ -254,3 +260,5 @@ output "metadata_store_users" {
     }
   }
 }
+
+

--- a/variables.tf
+++ b/variables.tf
@@ -135,6 +135,11 @@ variable "metadata_store_bgdc_username" {
   default     = "bgdc-reader"
 }
 
+variable "metadata_store_kickstart_username" {
+  description = "Username for metadata store writer Kickstart ADG user"
+  default     = "kickstart-adg-writer"
+}
+
 variable "htme_data_location" {
   default = {
     development = "businessdata/mongo/ucdata/2020-07-06/full/"


### PR DESCRIPTION
Hello,

This change is for adding new user for kickstart adg process which will have write access on hive metastore RDS mysql instance. As per this change following files has been altered

1. variables.tf -> add new variable with username for kickstart adg process
2. metastore.tf -> add new resource to create secret manager which stores metastore kickstart adg process
3. lambda_manage_mysql_user.tf -> updated the lambda role policy document to allow access to new secrets manager for kickstart
4. meta.yml -> add new plan for rotating mysql password for kickstart adg process
5. rotate-mysql-password-kickstart-adg.yml --> This is the new file stores plan for all environment

Requesting you to review and let me know in case of any concern

Thanks and Regards
Ashis Prasad