### PR TITLE
Use m5.16xlarge instead as there are no 24xlarges left in the AZs

### DIFF
--- a/cluster_config.tf
+++ b/cluster_config.tf
@@ -51,11 +51,11 @@ resource "aws_s3_bucket_object" "steps" {
 # See https://aws.amazon.com/blogs/big-data/best-practices-for-successfully-managing-memory-for-apache-spark-applications-on-amazon-emr/
 locals {
   spark_num_executors_per_instance = {
-    development = 3 # 8 cores (minus one) for m5.24xlarge / 2 executors per core
-    qa          = 19
+    development = 3 # 8 cores (minus one) for m5.2xlarge / 2 executors per core
+    qa          = 12
     integration = 3
     preprod     = 3
-    production  = 19 # 96 cores (minus one) for m5.24xlarge / 5 executors per core
+    production  = 12 # 64 cores (minus one) for m5.16xlarge / 5 executors per core
   }
   spark_executor_total_memory = floor(var.emr_yarn_memory_gb_per_core_instance[local.environment] / local.spark_num_executors_per_instance[local.environment])
   spark_executor_cores = {
@@ -67,24 +67,24 @@ locals {
   }
   spark_executor_memory = {
     development = 10
-    qa          = 18
+    qa          = 19
     integration = 10
     preprod     = 10
-    production  = 18 # 19 executors per instance for 24xlarge works out as this split of RAM each x 0.9
+    production  = 19 # 12 executors per instance for m5.16xlarge works out as this split of 256 RAM each x 0.9
   }
   spark_yarn_executor_memory_overhead = {
     development = 2
     qa          = 2
     integration = 2
     preprod     = 2
-    production  = 2 # 0.1 of the 20 per executor
+    production  = 2 # 0.1 of the 21 per executor
   }
   spark_driver_memory = {
     development = 10
-    qa          = 18
+    qa          = 19
     integration = 10
     preprod     = 10
-    production  = 18 # Same as executor memory
+    production  = 19 # Same as executor memory
   }
   spark_driver_cores = {
     development = 2
@@ -113,7 +113,6 @@ resource "aws_s3_bucket_object" "configurations" {
       proxy_http_port                     = data.terraform_remote_state.internal_compute.outputs.internet_proxy.port
       proxy_https_host                    = data.terraform_remote_state.internal_compute.outputs.internet_proxy.host
       proxy_https_port                    = data.terraform_remote_state.internal_compute.outputs.internet_proxy.port
-      emrfs_metadata_tablename            = local.emrfs_metadata_tablename
       s3_htme_bucket                      = data.terraform_remote_state.ingest.outputs.s3_buckets.htme_bucket
       spark_executor_cores                = local.spark_executor_cores[local.environment]
       spark_executor_memory               = local.spark_executor_memory[local.environment]

--- a/cluster_config/configurations.yaml.tpl
+++ b/cluster_config/configurations.yaml.tpl
@@ -72,14 +72,8 @@ Configurations:
 
 - Classification: "emrfs-site"
   Properties:
-    "fs.s3.consistent": "true"
-    "fs.s3.consistent.metadata.read.capacity": "800"
-    "fs.s3.consistent.metadata.write.capacity": "200"
     "fs.s3.maxConnections": "10000"
-    "fs.s3.consistent.retryPolicyType": "fixed"
-    "fs.s3.consistent.retryPeriodSeconds": "2"
-    "fs.s3.consistent.retryCount": "10"
-    "fs.s3.consistent.metadata.tableName": "${emrfs_metadata_tablename}"
+    "fs.s3.maxRetries": "20"
 - Classification: "spark-env"
   Configurations:
   - Classification: "export"

--- a/emr_jobflow_role.tf
+++ b/emr_jobflow_role.tf
@@ -208,7 +208,6 @@ data "aws_iam_policy_document" "analytical_dataset_generator_write_dynamodb" {
     ]
 
     resources = [
-      "arn:aws:dynamodb:${var.region}:${local.account[local.environment]}:table/${local.emrfs_metadata_tablename}",
       "arn:aws:dynamodb:${var.region}:${local.account[local.environment]}:table/${local.data_pipeline_metadata}"
     ]
   }

--- a/local.tf
+++ b/local.tf
@@ -131,7 +131,6 @@ locals {
   cw_agent_metrics_collection_interval = 60
 
   s3_log_prefix            = "emr/analytical_dataset_generator"
-  emrfs_metadata_tablename = "Analytical_Dataset_Generation_Metadata"
   data_pipeline_metadata   = data.terraform_remote_state.internal_compute.outputs.data_pipeline_metadata_dynamo.name
 
   published_nonsensitive_prefix = "runmetadata"

--- a/variables.tf
+++ b/variables.tf
@@ -54,20 +54,20 @@ variable "emr_release" {
 variable "emr_instance_type" {
   default = {
     development = "m5.2xlarge"
-    qa          = "m5.24xlarge"
+    qa          = "m5.16xlarge"
     integration = "m5.2xlarge"
     preprod     = "m5.2xlarge"
-    production  = "m5.24xlarge"
+    production  = "m5.16xlarge"
   }
 }
 
 variable "emr_core_instance_count" {
   default = {
     development = "5"
-    qa          = "20"
+    qa          = "22"
     integration = "5"
     preprod     = "5"
-    production  = "20"
+    production  = "22"
   }
 }
 
@@ -84,10 +84,10 @@ variable "spark_kyro_buffer" {
 variable "spark_executor_instances" {
   default = {
     development = 14 # 3 executors per instance x 5 instances minus 1 for driver
-    qa          = 379
+    qa          = 263
     integration = 14
     preprod     = 14
-    production  = 379 # 19 executors per instance x 20 instances minus 1 for driver
+    production  = 263 # 12 executors per instance x 22 instances minus 1 for driver
   }
 }
 


### PR DESCRIPTION
Use m5.16xlarge instead as there are no 24xlarges left in the AZs