### PR TITLE
Add flush at start to ensure pushgateway is always cleared

### DIFF
--- a/cluster_config/steps.yaml.tpl
+++ b/cluster_config/steps.yaml.tpl
@@ -1,11 +1,5 @@
 ---
 BootstrapActions:
-- Name: "courtesy-flush-pushgateway"
-  HadoopJarStep:
-    Args:
-    - "s3://${s3_config_bucket}/component/analytical-dataset-generation/flush-pushgateway.sh"
-    Jar: "s3://eu-west-2.elasticmapreduce/libs/script-runner/script-runner.jar"
-  ActionOnFailure: "${action_on_failure}"
 - Name: "start_ssm"
   ScriptBootstrapAction:
     Path: "s3://${s3_config_bucket}/component/analytical-dataset-generation/start_ssm.sh"
@@ -22,6 +16,12 @@ BootstrapActions:
   ScriptBootstrapAction:
     Path: "s3://${s3_config_bucket}/component/analytical-dataset-generation/metrics-setup.sh"
 Steps:
+- Name: "courtesy-flush-pushgateway"
+  HadoopJarStep:
+    Args:
+    - "s3://${s3_config_bucket}/component/analytical-dataset-generation/flush-pushgateway.sh"
+    Jar: "s3://eu-west-2.elasticmapreduce/libs/script-runner/script-runner.jar"
+  ActionOnFailure: "${action_on_failure}"
 - Name: "hive-setup"
   HadoopJarStep:
     Args:

--- a/cluster_config/steps.yaml.tpl
+++ b/cluster_config/steps.yaml.tpl
@@ -1,5 +1,11 @@
 ---
 BootstrapActions:
+- Name: "courtesy-flush-pushgateway"
+  HadoopJarStep:
+    Args:
+    - "s3://${s3_config_bucket}/component/analytical-dataset-generation/flush-pushgateway.sh"
+    Jar: "s3://eu-west-2.elasticmapreduce/libs/script-runner/script-runner.jar"
+  ActionOnFailure: "${action_on_failure}"
 - Name: "start_ssm"
   ScriptBootstrapAction:
     Path: "s3://${s3_config_bucket}/component/analytical-dataset-generation/start_ssm.sh"


### PR DESCRIPTION
We need to flush at the start and at the end of a run.  When the cluster job fails, it does not clear down the pushgateway and leaves messy, and confusing metrics.