### PR TITLE
Reduce wait to a suitable window

### DIFF
--- a/steps/flush-pushgateway.sh
+++ b/steps/flush-pushgateway.sh
@@ -6,19 +6,19 @@
 
 set -euo pipefail
 (
-# Import the logging functions
-source /opt/emr/logging.sh
-
-function log_wrapper_message() {
-    log_adg_message "$${1}" "flush-pushgateway.sh" "Running as: ,$USER"
-}
-
-log_wrapper_message "Sleeping for 5m"
-
-sleep 300
-
-log_wrapper_message "Flushing the ADG pushgateway"
-curl -X PUT http://${adg_pushgateway_hostname}:9091/api/v1/admin/wipe
-log_wrapper_message "Done flushing the ADG pushgateway"
-
+    # Import the logging functions
+    source /opt/emr/logging.sh
+    
+    function log_wrapper_message() {
+        log_adg_message "$${1}" "flush-pushgateway.sh" "Running as: ,$USER"
+    }
+    
+    log_wrapper_message "Sleeping for 5m"
+    
+    sleep 75 # scrape interval is 60, scrape timeout is 10, 5 for the pot
+    
+    log_wrapper_message "Flushing the ADG pushgateway"
+    curl -X PUT http://${adg_pushgateway_hostname}:9091/api/v1/admin/wipe
+    log_wrapper_message "Done flushing the ADG pushgateway"
+    
 ) >> /var/log/adg/flush-pushgateway.log 2>&1


### PR DESCRIPTION
Now we flush before and after running, the five minute sleep timer is excessive.  Scrape intervals are every 60 seconds, and scrape timeouts are 10 seconds.  This should suitably cover the final window, without costing too much time at either end of the run.