### PR TITLE
Split load over spots and on-demand

### DIFF
--- a/ci/jobs/dev/analytical-dataset-generation-dev.yml
+++ b/ci/jobs/dev/analytical-dataset-generation-dev.yml
@@ -1,94 +1,73 @@
 jobs:
-- name: analytical-dataset-generation-dev
-  max_in_flight: 1
-  plan:
-  - in_parallel:
-    - put: meta
-      resource: meta-development
-    - get: aws-analytical-dataset-generation
-      trigger: true
-    - get: emr-launcher-release
-      trigger: true
-    - get: analytical-dataset-generation-exporter-release
-      trigger: true
-    - get: aws-dataworks-e2e-framework
-      trigger: false
-    - get: aws-ingestion
-      trigger: false
-    - get: aws-internal-compute
-      trigger: false
-    - get: aws-common-infrastructure
-      trigger: false
-    - get: secrets-management
-      trigger: false
-    - get: emr-ami
-      trigger: true
-    - get: manage-mysql-user-release
-      trigger: true
-      params:
-       globs:
-         - "*.zip"
-  - .: (( inject meta.plan.unit-tests))
-  - .: (( inject meta.plan.terraform-bootstrap ))
-    config:
-      params:
-        AWS_ACC: ((aws_account.development))
-  - .: (( inject meta.plan.terraform-apply ))
-    params:
-      TF_WORKSPACE: default
-  - .: (( inject meta.plan.rotate-mysql-master-password ))
-    params:
-      TF_WORKSPACE: default
-      AWS_ACC: ((aws_account.development))
-      AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci
-      inputs:
-        - name: secrets-management
-  - .: (( inject meta.plan.terraform-plan ))
-    params:
-      TF_WORKSPACE: default
-  - in_parallel:
-    - .: (( inject meta.plan.terraform-output-internal-compute ))
-      config:
-        params:
-          TF_WORKSPACE: default
-          AWS_ACC: ((aws_account.development))
-          AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci
-    - .: (( inject meta.plan.terraform-output-ingest ))
-      config:
-        params:
-          TF_WORKSPACE: default
-          AWS_ACC: ((aws_account.development))
-          AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci
-    - .: (( inject meta.plan.terraform-output-adg ))
-      config:
-        params:
-          TF_WORKSPACE: default
-          AWS_ACC: ((aws_account.development))
-          AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci
-    - .: (( inject meta.plan.terraform-output-common-infrastructure ))
-      config:
-        params:
-          TF_WORKSPACE: default
-          AWS_ACC: ((aws_account.development))
-          AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci
-  - .: (( inject meta.plan.e2e-tests))
-    config:
-      params:
-        TF_WORKSPACE: default
-        AWS_ACC: ((aws_account.development))
-        AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci
-    ensure:
-      do:
-        - .: (( inject meta.plan.stop-cluster ))
-          task: stop-full-clusters
-          config:
+  - name: analytical-dataset-generation-dev
+    max_in_flight: 1
+    plan:
+      - in_parallel:
+          - put: meta
+            resource: meta-development
+          - get: aws-analytical-dataset-generation
+            trigger: true
+          - get: emr-launcher-release
+            trigger: true
+          - get: analytical-dataset-generation-exporter-release
+            trigger: true
+          - get: aws-dataworks-e2e-framework
+            trigger: false
+          - get: aws-ingestion
+            trigger: false
+          - get: aws-internal-compute
+            trigger: false
+          - get: aws-common-infrastructure
+            trigger: false
+          - get: secrets-management
+            trigger: false
+          - get: emr-ami
+            trigger: true
+          - get: manage-mysql-user-release
+            trigger: true
             params:
-              AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci
-              SNAPSHOT_TYPE: "full"
-        - .: (( inject meta.plan.stop-cluster ))
-          task: stop-incremental-clusters
-          config:
-            params:
-              AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci
-              SNAPSHOT_TYPE: "incremental"
-
+              globs:
+                - "*.zip"
+      - .: (( inject meta.plan.unit-tests))
+      - .: (( inject meta.plan.terraform-bootstrap ))
+        config:
+          params:
+            AWS_ACC: ((aws_account.development))
+      - .: (( inject meta.plan.terraform-apply ))
+        params:
+          TF_WORKSPACE: default
+      - .: (( inject meta.plan.rotate-mysql-master-password ))
+        params:
+          TF_WORKSPACE: default
+          AWS_ACC: ((aws_account.development))
+          AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci
+          inputs:
+            - name: secrets-management
+      - .: (( inject meta.plan.terraform-plan ))
+        params:
+          TF_WORKSPACE: default
+      - in_parallel:
+          - .: (( inject meta.plan.terraform-output-internal-compute ))
+            config:
+              params:
+                TF_WORKSPACE: default
+                AWS_ACC: ((aws_account.development))
+                AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci
+          - .: (( inject meta.plan.terraform-output-ingest ))
+            config:
+              params:
+                TF_WORKSPACE: default
+                AWS_ACC: ((aws_account.development))
+                AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci
+          - .: (( inject meta.plan.terraform-output-adg ))
+            config:
+              params:
+                TF_WORKSPACE: default
+                AWS_ACC: ((aws_account.development))
+                AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci
+          - .: (( inject meta.plan.terraform-output-common-infrastructure ))
+            config:
+              params:
+                TF_WORKSPACE: default
+                AWS_ACC: ((aws_account.development))
+                AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci

--- a/cluster_config.tf
+++ b/cluster_config.tf
@@ -36,6 +36,7 @@ resource "aws_s3_bucket_object" "instances" {
       instance_type_core_three = var.emr_instance_type_core_three[local.environment]
       instance_type_master     = var.emr_instance_type_master[local.environment]
       core_instance_count      = var.emr_core_instance_count[local.environment]
+      core_spot_instance_count = var.emr_core_spot_instance_count[local.environment]
     }
   )
 }

--- a/cluster_config/instances.yaml.tpl
+++ b/cluster_config/instances.yaml.tpl
@@ -54,4 +54,4 @@ Instances:
         - SpotSpecification: 
             AllocationStrategy: "capacity-optimized"
             TimeoutDurationMinutes: "120"
-            TimeoutAction: "TERMINATE_CLUSTER"
+            TimeoutAction: "SWITCH_TO_ON_DEMAND"

--- a/cluster_config/instances.yaml.tpl
+++ b/cluster_config/instances.yaml.tpl
@@ -24,6 +24,7 @@ Instances:
   - InstanceFleetType: "CORE"
     Name: CORE
     TargetOnDemandCapacity: ${core_instance_count}
+    TargetSpotCapacity: ${core_spot_instance_count}
     InstanceTypeConfigs:
     - EbsConfiguration:
         EbsBlockDeviceConfigs:
@@ -46,3 +47,11 @@ Instances:
             VolumeType: "gp2"
           VolumesPerInstance: 1
       InstanceType: "${instance_type_core_three}"
+      BidPriceAsPercentageOfOnDemandPrice: "100"
+    LaunchSpecifications:
+    - OnDemandSpecification: 
+        AllocationStrategy: "lowest-price"
+        - SpotSpecification: 
+            AllocationStrategy: "capacity-optimized"
+            TimeoutDurationMinutes: "120"
+            TimeoutAction: "TERMINATE_CLUSTER"

--- a/variables.tf
+++ b/variables.tf
@@ -93,11 +93,21 @@ variable "emr_instance_type_core_three" {
 
 variable "emr_core_instance_count" {
   default = {
-    development = "5"
-    qa          = "5"
-    integration = "5"
-    preprod     = "5"
-    production  = "25"
+    development = "3"
+    qa          = "3"
+    integration = "3"
+    preprod     = "3"
+    production  = "15"
+  }
+}
+
+variable "emr_core_spot_instance_count" {
+  default = {
+    development = "2"
+    qa          = "2"
+    integration = "2"
+    preprod     = "2"
+    production  = "10"
   }
 }
 


### PR DESCRIPTION
This splits the `CORE` node requests over spot instances and on-demand instances.  If spot instances fail, it will attempt on-demand.