### PR TITLE
Trigger pdm

### DIFF
--- a/bootstrap_actions.tf
+++ b/bootstrap_actions.tf
@@ -31,6 +31,7 @@ resource "aws_s3_bucket_object" "emr_setup_sh" {
   content = templatefile("${path.module}/bootstrap_actions/emr-setup.sh",
     {
       ADG_LOG_LEVEL                   = local.adg_log_level[local.environment]
+      CREATE_PDM_TRIGGER              = format("s3://%s/%s", data.terraform_remote_state.common.outputs.config_bucket.id, aws_s3_bucket_object.create_pdm_trigger_script.key)
       S3_SEND_SNS_NOTIFICATION        = format("s3://%s/%s", data.terraform_remote_state.common.outputs.config_bucket.id, aws_s3_bucket_object.send_notification_script.key)
       RESUME_STEP_SHELL               = format("s3://%s/%s", data.terraform_remote_state.common.outputs.config_bucket.id, aws_s3_bucket_object.resume_step_script.key)
       aws_default_region              = "eu-west-2"

--- a/bootstrap_actions/cloudwatch.sh
+++ b/bootstrap_actions/cloudwatch.sh
@@ -150,6 +150,12 @@ cat > /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json <<CWAGEN
             "timezone": "UTC"
           },
           {
+            "file_path": "/var/log/adg/create_pdm_trigger.log",
+            "log_group_name": "$${cwa_steps_loggrp_name}",
+            "log_stream_name": "{instance_id}-create_pdm_trigger.log",
+            "timezone": "UTC"
+          },
+          {
             "file_path": "/var/log/adg/flush-pushgateway.log",
             "log_group_name": "$${cwa_steps_loggrp_name}",
             "log_stream_name": "{instance_id}-flush-pushgateway.log",

--- a/bootstrap_actions/emr-setup.sh
+++ b/bootstrap_actions/emr-setup.sh
@@ -2,6 +2,7 @@
 echo "Installing scripts"
 $(which aws) s3 cp "${S3_CLOUDWATCH_SHELL}"            /opt/emr/cloudwatch.sh
 $(which aws) s3 cp "${S3_SEND_SNS_NOTIFICATION}"       /opt/emr/send_notification.py
+$(which aws) s3 cp "${CREATE_PDM_TRIGGER}"             /opt/emr/create_pdm_trigger.py
 $(which aws) s3 cp "${RESUME_STEP_SHELL}"              /opt/emr/resume_step.sh
 $(which aws) s3 cp "${update_dynamo_sh}"               /opt/emr/update_dynamo.sh
 $(which aws) s3 cp "${dynamo_schema_json}"             /opt/emr/dynamo_schema.json
@@ -9,6 +10,7 @@ $(which aws) s3 cp "${dynamo_schema_json}"             /opt/emr/dynamo_schema.js
 echo "Changing the Permissions"
 chmod u+x /opt/emr/cloudwatch.sh
 chmod u+x /opt/emr/send_notification.py
+chmod u+x /opt/emr/create_pdm_trigger.py
 chmod u+x /opt/emr/resume_step.sh
 chmod u+x /opt/emr/update_dynamo.sh
 

--- a/bootstrap_actions/update_dynamo.sh
+++ b/bootstrap_actions/update_dynamo.sh
@@ -19,6 +19,8 @@
   S3_PREFIX_FILE=/opt/emr/s3_prefix.txt
   SNAPSHOT_TYPE_FILE=/opt/emr/snapshot_type.txt
   OUTPUT_LOCATION_FILE=/opt/emr/output_location.txt
+  EXPORT_DATE_FILE=/opt/emr/export_date.txt
+  
   DATE=$(date '+%Y-%m-%d')
   CLUSTER_ID=`cat /mnt/var/lib/info/job-flow.json | jq '.jobFlowId'`
   CLUSTER_ID=$${CLUSTER_ID//\"}
@@ -30,7 +32,7 @@
 
   FINAL_STEP_NAME="flush-pushgateway"
 
-  while [[ ! -f $CORRELATION_ID_FILE ]] && [[ ! -f $S3_PREFIX_FILE ]] && [[ ! -f $SNAPSHOT_TYPE_FILE ]]
+  while [[ ! -f $CORRELATION_ID_FILE ]] && [[ ! -f $S3_PREFIX_FILE ]] && [[ ! -f $SNAPSHOT_TYPE_FILE ]] && [[ ! -f $EXPORT_DATE_FILE ]]
   do
     sleep 5
   done
@@ -38,7 +40,13 @@
   CORRELATION_ID=`cat $CORRELATION_ID_FILE`
   S3_PREFIX=`cat $S3_PREFIX_FILE`
   SNAPSHOT_TYPE=`cat $SNAPSHOT_TYPE_FILE`
+  EXPORT_DATE=`cat $EXPORT_DATE_FILE`
   DATA_PRODUCT="ADG-$SNAPSHOT_TYPE"
+
+  if [[ -z "$EXPORT_DATE" ]]l; then
+    log_wrapper_message "Export date from file was empty, so defaulting to today's date"
+    EXPORT_DATE="$DATE"
+  fi
 
   while [ ! -f $STEP_DEATILS_DIR/*.json ]
   do

--- a/bootstrap_actions/update_dynamo.sh
+++ b/bootstrap_actions/update_dynamo.sh
@@ -124,6 +124,9 @@
       state=$(jq -r '.state' $i)
       while [[ "$state" != "$COMPLETED_STATUS" ]]; do
         step_script_name=$(jq -r '.args[0]' $i)
+        if [[ "$step_script_name" == "python3" ]]; then
+            step_script_name=$(jq -r '.args[1]' $i)
+        fi
         CURRENT_STEP=$(echo "$step_script_name" | sed 's:.*/::' | cut -f 1 -d '.')
         state=$(jq -r '.state' $i)
         if [[ "$state" == "$FAILED_STATUS" ]] || [[ "$state" == "$CANCELLED_STATUS" ]]; then

--- a/bootstrap_actions/update_dynamo.sh
+++ b/bootstrap_actions/update_dynamo.sh
@@ -81,10 +81,10 @@
     ttl_value=$(get_ttl)
     output_location_value=$(get_output_location)
 
-    log_wrapper_message "Updating DynamoDB with Correlation_Id: $CORRELATION_ID, DataProduct: $DATA_PRODUCT, Date: $DATE, Cluster_Id: $CLUSTER_ID, S3_Prefix_Snapshots: $S3_PREFIX, S3_Prefix_Analytical_DataSet: $output_location_value, Snapshot_Type: $SNAPSHOT_TYPE, TimeToExist: $ttl_value, CurrentStep: $current_step, Status: $status, Run_Id: $run_id"
+    log_wrapper_message "Updating DynamoDB with Correlation_Id: $CORRELATION_ID, DataProduct: $DATA_PRODUCT, Date: $EXPORT_DATE, Cluster_Id: $CLUSTER_ID, S3_Prefix_Snapshots: $S3_PREFIX, S3_Prefix_Analytical_DataSet: $output_location_value, Snapshot_Type: $SNAPSHOT_TYPE, TimeToExist: $ttl_value, CurrentStep: $current_step, Status: $status, Run_Id: $run_id"
 
     update_expression="SET #d = :s, Cluster_Id = :v, S3_Prefix_Snapshots = :w, Snapshot_Type = :x, TimeToExist = :z"
-    expression_values="\":s\": {\"S\":\"$DATE\"}, \":v\": {\"S\":\"$CLUSTER_ID\"}, \":w\": {\"S\":\"$S3_PREFIX\"}, \":x\": {\"S\":\"$SNAPSHOT_TYPE\"}, \":z\": {\"N\":\"$ttl_value\"}"
+    expression_values="\":s\": {\"S\":\"$EXPORT_DATE\"}, \":v\": {\"S\":\"$CLUSTER_ID\"}, \":w\": {\"S\":\"$S3_PREFIX\"}, \":x\": {\"S\":\"$SNAPSHOT_TYPE\"}, \":z\": {\"N\":\"$ttl_value\"}"
     expression_names="\"#d\":\"Date\""
 
     if [[ ! -z "$current_step" ]] && [[ "$current_step" != "NOT_SET" ]]; then

--- a/bootstrap_actions/update_dynamo.sh
+++ b/bootstrap_actions/update_dynamo.sh
@@ -43,7 +43,7 @@
   EXPORT_DATE=`cat $EXPORT_DATE_FILE`
   DATA_PRODUCT="ADG-$SNAPSHOT_TYPE"
 
-  if [[ -z "$EXPORT_DATE" ]]l; then
+  if [[ -z "$EXPORT_DATE" ]]; then
     log_wrapper_message "Export date from file was empty, so defaulting to today's date"
     EXPORT_DATE="$DATE"
   fi

--- a/ci/jobs/dev/admin/start.yml
+++ b/ci/jobs/dev/admin/start.yml
@@ -9,5 +9,6 @@ jobs:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci
             AWS_ACC: ((aws_account.development))
             S3_PREFIX: businessdata/mongo/ucdata/2020-07-06/full/
+            EXPORT_DATE: "2020-07-06"
             CORRELATION_ID: test
             SNAPSHOT_TYPE: full

--- a/ci/jobs/dev/analytical-dataset-generation-dev.yml
+++ b/ci/jobs/dev/analytical-dataset-generation-dev.yml
@@ -6,7 +6,6 @@ jobs:
           - put: meta
             resource: meta-development
           - get: aws-analytical-dataset-generation
-            resource: aws-analytical-dataset-generation-steven
             trigger: true
           - get: emr-launcher-release
             trigger: true
@@ -17,7 +16,6 @@ jobs:
           - get: analytical-dataset-generation-exporter-release
             trigger: true
           - get: dataworks-behavioural-framework
-            resource: dataworks-behavioural-framework-steven
             trigger: false
           - get: secrets-management
             trigger: false

--- a/ci/jobs/dev/analytical-dataset-generation-dev.yml
+++ b/ci/jobs/dev/analytical-dataset-generation-dev.yml
@@ -6,7 +6,6 @@ jobs:
           - put: meta
             resource: meta-development
           - get: aws-analytical-dataset-generation
-            resource: aws-analytical-dataset-generation-steven
             trigger: true
           - get: emr-launcher-release
             trigger: true

--- a/ci/jobs/dev/analytical-dataset-generation-dev.yml
+++ b/ci/jobs/dev/analytical-dataset-generation-dev.yml
@@ -6,6 +6,7 @@ jobs:
           - put: meta
             resource: meta-development
           - get: aws-analytical-dataset-generation
+            resource: aws-analytical-dataset-generation-steven
             trigger: true
           - get: emr-launcher-release
             trigger: true
@@ -16,6 +17,7 @@ jobs:
           - get: analytical-dataset-generation-exporter-release
             trigger: true
           - get: dataworks-behavioural-framework
+            resource: dataworks-behavioural-framework-steven
             trigger: false
           - get: secrets-management
             trigger: false

--- a/ci/jobs/dev/analytical-dataset-generation-dev.yml
+++ b/ci/jobs/dev/analytical-dataset-generation-dev.yml
@@ -6,6 +6,7 @@ jobs:
           - put: meta
             resource: meta-development
           - get: aws-analytical-dataset-generation
+            resource: aws-analytical-dataset-generation-steven
             trigger: true
           - get: emr-launcher-release
             trigger: true

--- a/ci/jobs/integration/admin/start.yml
+++ b/ci/jobs/integration/admin/start.yml
@@ -9,5 +9,6 @@ jobs:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.integration)):role/ci
             AWS_ACC: ((aws_account.integration))
             S3_PREFIX: businessdata/mongo/ucdata/2020-08-07/full/
+            EXPORT_DATE: "2020-08-07"
             CORRELATION_ID: test
             SNAPSHOT_TYPE: full

--- a/ci/jobs/preprod/admin/start.yml
+++ b/ci/jobs/preprod/admin/start.yml
@@ -9,5 +9,6 @@ jobs:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.preprod)):role/ci
             AWS_ACC: ((aws_account.preprod))
             S3_PREFIX: businessdata/mongo/ucdata/2020-07-06/full/
+            EXPORT_DATE: "2020-07-06"
             CORRELATION_ID: test
             SNAPSHOT_TYPE: full

--- a/ci/jobs/production/admin/start.yml
+++ b/ci/jobs/production/admin/start.yml
@@ -9,5 +9,6 @@ jobs:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.production)):role/ci
             AWS_ACC: ((aws_account.production))
             S3_PREFIX: businessdata/mongo/ucdata/2021-03-09/full
+            EXPORT_DATE: "2021-03-09"
             CORRELATION_ID: ingest_emr_scheduled_tasks_export_snapshots_to_crown_production_full_94_full
             SNAPSHOT_TYPE: full

--- a/ci/jobs/production/admin/start.yml
+++ b/ci/jobs/production/admin/start.yml
@@ -8,6 +8,6 @@ jobs:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.production)):role/ci
             AWS_ACC: ((aws_account.production))
-            S3_PREFIX: businessdata/mongo/ucdata/2021-03-05/incremental
-            CORRELATION_ID: test
+            S3_PREFIX: businessdata/mongo/ucdata/2021-03-09/full
+            CORRELATION_ID: ingest_emr_scheduled_tasks_export_snapshots_to_crown_production_full_94_full
             SNAPSHOT_TYPE: full

--- a/ci/jobs/qa/admin/start.yml
+++ b/ci/jobs/qa/admin/start.yml
@@ -9,5 +9,6 @@ jobs:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.qa)):role/ci
             AWS_ACC: ((aws_account.qa))
             S3_PREFIX: businessdata/mongo/ucdata/2020-07-06/full/
+            EXPORT_DATE: "2020-07-06"
             CORRELATION_ID: test
             SNAPSHOT_TYPE: full

--- a/ci/meta.yml
+++ b/ci/meta.yml
@@ -394,7 +394,8 @@ meta:
               {
                 "correlation_id": "$CORRELATION_ID",
                 "s3_prefix": "$S3_PREFIX",
-                "snapshot_type": "$SNAPSHOT_TYPE"
+                "snapshot_type": "$SNAPSHOT_TYPE",
+                "export_date": "$EXPORT_DATE"
               }
               EOF
               )

--- a/ci/resources.yml
+++ b/ci/resources.yml
@@ -16,6 +16,15 @@ resources:
     check_every: 720h
     webhook_token: ((dataworks.concourse_github_webhook_token))
 
+  - name: aws-analytical-dataset-generation-steven
+    type: git
+    source:
+      branch: trigger-pdm
+      repository: dwp/aws-analytical-dataset-generation
+      uri: https://github.com/dwp/aws-analytical-dataset-generation.git
+    check_every: 720h
+    webhook_token: ((dataworks.concourse_github_webhook_token))
+
   - name: aws-analytical-dataset-generation-update-pipeline
     type: git
     source:

--- a/ci/resources.yml
+++ b/ci/resources.yml
@@ -16,6 +16,15 @@ resources:
     check_every: 720h
     webhook_token: ((dataworks.concourse_github_webhook_token))
 
+  - name: aws-analytical-dataset-generation-steven
+    type: git
+    source:
+      branch: trigger-pdm
+      repository: dwp/aws-analytical-dataset-generation
+      uri: https://github.com/dwp/aws-analytical-dataset-generation.git
+    check_every: 720h
+    webhook_token: ((dataworks.concourse_github_webhook_token))
+
   - name: aws-analytical-dataset-generation-update-pipeline
     type: git
     source:
@@ -50,6 +59,15 @@ resources:
     type: git
     source:
       branch: master
+      uri: https://github.com/dwp/dataworks-behavioural-framework.git
+      access_token: ((dataworks-secrets.concourse_github_pat))
+    webhook_token: ((dataworks.concourse_github_webhook_token))
+    check_every: 5m
+
+  - name: dataworks-behavioural-framework-steven
+    type: git
+    source:
+      branch: check-meta
       uri: https://github.com/dwp/dataworks-behavioural-framework.git
       access_token: ((dataworks-secrets.concourse_github_pat))
     webhook_token: ((dataworks.concourse_github_webhook_token))

--- a/ci/resources.yml
+++ b/ci/resources.yml
@@ -16,15 +16,6 @@ resources:
     check_every: 720h
     webhook_token: ((dataworks.concourse_github_webhook_token))
 
-  - name: aws-analytical-dataset-generation-steven
-    type: git
-    source:
-      branch: trigger-pdm
-      repository: dwp/aws-analytical-dataset-generation
-      uri: https://github.com/dwp/aws-analytical-dataset-generation.git
-    check_every: 720h
-    webhook_token: ((dataworks.concourse_github_webhook_token))
-
   - name: aws-analytical-dataset-generation-update-pipeline
     type: git
     source:

--- a/ci/resources.yml
+++ b/ci/resources.yml
@@ -16,15 +16,6 @@ resources:
     check_every: 720h
     webhook_token: ((dataworks.concourse_github_webhook_token))
 
-  - name: aws-analytical-dataset-generation-steven
-    type: git
-    source:
-      branch: trigger-pdm
-      repository: dwp/aws-analytical-dataset-generation
-      uri: https://github.com/dwp/aws-analytical-dataset-generation.git
-    check_every: 720h
-    webhook_token: ((dataworks.concourse_github_webhook_token))
-
   - name: aws-analytical-dataset-generation-update-pipeline
     type: git
     source:
@@ -59,15 +50,6 @@ resources:
     type: git
     source:
       branch: master
-      uri: https://github.com/dwp/dataworks-behavioural-framework.git
-      access_token: ((dataworks-secrets.concourse_github_pat))
-    webhook_token: ((dataworks.concourse_github_webhook_token))
-    check_every: 5m
-
-  - name: dataworks-behavioural-framework-steven
-    type: git
-    source:
-      branch: check-meta
       uri: https://github.com/dwp/dataworks-behavioural-framework.git
       access_token: ((dataworks-secrets.concourse_github_pat))
     webhook_token: ((dataworks.concourse_github_webhook_token))

--- a/cluster_config/cluster.yaml.tpl
+++ b/cluster_config/cluster.yaml.tpl
@@ -30,7 +30,3 @@ Tags:
   Value: "aws-analytical-dataset-generator"
 - Key: "Name"
   Value: "aws-analytical-dataset-generator"
-- Key: "snapshot_type"
-  Value: "NOT_SET"
-- Key: "export_date"
-  Value: "NOT_SET"

--- a/cluster_config/cluster.yaml.tpl
+++ b/cluster_config/cluster.yaml.tpl
@@ -32,3 +32,5 @@ Tags:
   Value: "aws-analytical-dataset-generator"
 - Key: "snapshot_type"
   Value: "NOT_SET"
+- Key: "export_date"
+  Value: "NOT_SET"

--- a/cluster_config/steps.yaml.tpl
+++ b/cluster_config/steps.yaml.tpl
@@ -48,6 +48,13 @@ Steps:
     - "/opt/emr/generate_dataset_from_htme.py"
     Jar: "command-runner.jar"
   ActionOnFailure: "${action_on_failure}"
+- Name: "create_pdm_trigger"
+  HadoopJarStep:
+    Args:
+    - "python3"
+    - "/opt/emr/create_pdm_trigger.py"
+    Jar: "command-runner.jar"
+  ActionOnFailure: "${action_on_failure}"
 - Name: "sns-notification"
   HadoopJarStep:
     Args:

--- a/emr_jobflow_role.tf
+++ b/emr_jobflow_role.tf
@@ -357,6 +357,6 @@ data "aws_iam_policy_document" "adg_cloudwatch_topic_policy_for_pdm_trigger" {
 
     effect = "Allow"
 
-    resources = [*]
+    resources = ["*"]
   }
 }

--- a/emr_jobflow_role.tf
+++ b/emr_jobflow_role.tf
@@ -307,7 +307,6 @@ resource "aws_iam_role_policy_attachment" "analytical_dataset_generator_read_htm
   policy_arn = aws_iam_policy.analytical_dataset_generator_read_htme.arn
 }
 
-
 resource "aws_iam_policy" "analytical_dataset_generator_publish_sns" {
   name        = "AnalyticalDatasetGeneratorPublishSns"
   description = "Allow ADG to publish SNS messages"
@@ -332,5 +331,32 @@ data "aws_iam_policy_document" "adg_sns_topic_policy_for_completion_status" {
     resources = [
       aws_sns_topic.adg_completion_status_sns.arn,
     ]
+  }
+}
+
+resource "aws_iam_policy" "adg_cloudwatch_topic_policy_for_pdm_trigger" {
+  name        = "AdgPDMTrigger"
+  description = "Allow ADG to publish Cloudwatch rules and targets"
+  policy      = data.aws_iam_policy_document.adg_cloudwatch_topic_policy_for_pdm_trigger.json
+}
+
+resource "aws_iam_role_policy_attachment" "adg_cloudwatch_topic_policy_for_pdm_trigger" {
+  role       = aws_iam_role.analytical_dataset_generator.name
+  policy_arn = aws_iam_policy.adg_cloudwatch_topic_policy_for_pdm_trigger.arn
+}
+
+data "aws_iam_policy_document" "adg_cloudwatch_topic_policy_for_pdm_trigger" {
+  statement {
+    sid = "AdgPDMTriggerPolicy"
+
+    actions = [
+      "events:EnableRule",
+      "events:PutRule",
+      "events:PutTargets",
+    ]
+
+    effect = "Allow"
+
+    resources = [*]
   }
 }

--- a/local.tf
+++ b/local.tf
@@ -240,4 +240,12 @@ locals {
     preprod     = "0"
     production  = "2"
   }
+
+  adg_alerts = {
+    development = true
+    qa          = false
+    integration = false
+    preprod     = false
+    production  = true
+  }
 }

--- a/local.tf
+++ b/local.tf
@@ -218,7 +218,7 @@ locals {
   }
 
   skip_pdm_trigger_on_adg_completion = {
-    development = "false"
+    development = "true"
     qa          = "true"
     integration = "true"
     preprod     = "true"
@@ -242,7 +242,7 @@ locals {
   }
 
   adg_alerts = {
-    development = true
+    development = false
     qa          = false
     integration = false
     preprod     = false

--- a/local.tf
+++ b/local.tf
@@ -217,6 +217,14 @@ locals {
     production  = "0.0.28"
   }
 
+  skip_pdm_trigger_on_adg_completion = {
+    development = "true"
+    qa          = "true"
+    integration = "true"
+    preprod     = "true"
+    production  = "false"
+  }
+
   skip_sns_notification_on_adg_completion = {
     development = "true"
     qa          = "true"

--- a/local.tf
+++ b/local.tf
@@ -218,7 +218,7 @@ locals {
   }
 
   skip_pdm_trigger_on_adg_completion = {
-    development = "true"
+    development = "false"
     qa          = "true"
     integration = "true"
     preprod     = "true"

--- a/pdm_emr_launcher.tf
+++ b/pdm_emr_launcher.tf
@@ -32,19 +32,6 @@ resource "aws_lambda_function" "pdm_cw_emr_launcher" {
   }
 }
 
-resource "aws_cloudwatch_event_rule" "pdm_cw_emr_launcher_schedule" {
-  name                = "pdm_cw_emr_launcher_schedule"
-  description         = "Triggers PDM EMR Launcher everyday at 7pm"
-  schedule_expression = format("cron(%s)", local.pdm_cw_emr_lambda_schedule[local.environment])
-}
-
-resource "aws_cloudwatch_event_target" "pdm_emr_launcher_target" {
-  rule      = aws_cloudwatch_event_rule.pdm_cw_emr_launcher_schedule.name
-  target_id = "pdm_cw_emr_launcher_target"
-  arn       = aws_lambda_function.pdm_cw_emr_launcher.arn
-}
-
-
 resource "aws_iam_role" "pdm_emr_launcher_lambda_role" {
   name               = "pdm_cw_emr_launcher_lambda_role"
   assume_role_policy = data.aws_iam_policy_document.pdm_emr_launcher_assume_policy.json
@@ -55,7 +42,6 @@ resource "aws_lambda_permission" "pdm_emr_relauncher_invoke_permission" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.pdm_cw_emr_launcher.function_name
   principal     = "events.amazonaws.com"
-  source_arn    = aws_cloudwatch_event_rule.pdm_cw_emr_launcher_schedule.arn
 }
 
 data "aws_iam_policy_document" "pdm_emr_launcher_assume_policy" {

--- a/slack-alerts.tf
+++ b/slack-alerts.tf
@@ -73,7 +73,31 @@ resource "aws_cloudwatch_event_rule" "adg_full_success" {
 EOF
 }
 
+resource "aws_cloudwatch_event_rule" "adg_full_running" {
+  name          = "adg_full_running"
+  description   = "checks that ADG is running"
+  event_pattern = <<EOF
+{
+  "source": [
+    "aws.emr"
+  ],
+  "detail-type": [
+    "EMR Cluster State Change"
+  ],
+  "detail": {
+    "state": [
+      "RUNNING"
+    ],
+    "name": [
+      "analytical-dataset-generator-full"
+    ]
+  }
+}
+EOF
+}
+
 resource "aws_cloudwatch_metric_alarm" "adg_full_failed" {
+  count                     = local.adg_alerts[local.environment] == true ? 1 : 0
   alarm_name                = "adg_full_failed"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
@@ -99,6 +123,7 @@ resource "aws_cloudwatch_metric_alarm" "adg_full_failed" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "adg_full_terminated" {
+  count                     = local.adg_alerts[local.environment] == true ? 1 : 0
   alarm_name                = "adg_full_terminated"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
@@ -124,6 +149,7 @@ resource "aws_cloudwatch_metric_alarm" "adg_full_terminated" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "adg_full_success" {
+  count                     = local.adg_alerts[local.environment] == true ? 1 : 0
   alarm_name                = "adg_full_success"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
@@ -142,6 +168,32 @@ resource "aws_cloudwatch_metric_alarm" "adg_full_success" {
     local.common_tags,
     {
       Name              = "adg_full_success",
+      notification_type = "Information",
+      severity          = "Critical"
+    },
+  )
+}
+
+resource "aws_cloudwatch_metric_alarm" "adg_full_running" {
+  count                     = local.adg_alerts[local.environment] == true ? 1 : 0
+  alarm_name                = "adg_full_running"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = "TriggeredRules"
+  namespace                 = "AWS/Events"
+  period                    = "60"
+  statistic                 = "Sum"
+  threshold                 = "1"
+  alarm_description         = "Monitoring adg full running"
+  insufficient_data_actions = []
+  alarm_actions             = [data.terraform_remote_state.security-tools.outputs.sns_topic_london_monitoring.arn]
+  dimensions = {
+    RuleName = aws_cloudwatch_event_rule.adg_full_running.name
+  }
+  tags = merge(
+    local.common_tags,
+    {
+      Name              = "adg_full_running",
       notification_type = "Information",
       severity          = "Critical"
     },
@@ -223,7 +275,31 @@ resource "aws_cloudwatch_event_rule" "adg_incremental_success" {
 EOF
 }
 
+resource "aws_cloudwatch_event_rule" "adg_incremental_running" {
+  name          = "adg_incremental_running"
+  description   = "checks that ADG is running steps"
+  event_pattern = <<EOF
+{
+  "source": [
+    "aws.emr"
+  ],
+  "detail-type": [
+    "EMR Cluster State Change"
+  ],
+  "detail": {
+    "state": [
+      "RUNNING"
+    ],
+    "name": [
+      "analytical-dataset-generator-incremental"
+    ]
+  }
+}
+EOF
+}
+
 resource "aws_cloudwatch_metric_alarm" "adg_incremental_failed" {
+  count                     = local.adg_alerts[local.environment] == true ? 1 : 0
   alarm_name                = "adg_incremental_failed"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
@@ -249,6 +325,7 @@ resource "aws_cloudwatch_metric_alarm" "adg_incremental_failed" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "adg_incremental_terminated" {
+  count                     = local.adg_alerts[local.environment] == true ? 1 : 0
   alarm_name                = "adg_incremental_terminated"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
@@ -274,6 +351,7 @@ resource "aws_cloudwatch_metric_alarm" "adg_incremental_terminated" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "adg_incremental_success" {
+  count                     = local.adg_alerts[local.environment] == true ? 1 : 0
   alarm_name                = "adg_incremental_success"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "1"
@@ -291,7 +369,33 @@ resource "aws_cloudwatch_metric_alarm" "adg_incremental_success" {
   tags = merge(
     local.common_tags,
     {
-      Name              = "adg_full_success",
+      Name              = "adg_incremental_success",
+      notification_type = "Information",
+      severity          = "Critical"
+    },
+  )
+}
+
+resource "aws_cloudwatch_metric_alarm" "adg_incremental_running" {
+  count                     = local.adg_alerts[local.environment] == true ? 1 : 0
+  alarm_name                = "adg_incremental_running"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = "TriggeredRules"
+  namespace                 = "AWS/Events"
+  period                    = "60"
+  statistic                 = "Sum"
+  threshold                 = "1"
+  alarm_description         = "Monitoring adg incremental running"
+  insufficient_data_actions = []
+  alarm_actions             = [data.terraform_remote_state.security-tools.outputs.sns_topic_london_monitoring.arn]
+  dimensions = {
+    RuleName = aws_cloudwatch_event_rule.adg_incremental_running.name
+  }
+  tags = merge(
+    local.common_tags,
+    {
+      Name              = "adg_incremental_running",
       notification_type = "Information",
       severity          = "Critical"
     },

--- a/steps.tf
+++ b/steps.tf
@@ -24,6 +24,7 @@ resource "aws_s3_bucket_object" "create_pdm_trigger_script" {
       pdm_lambda_trigger_arn  = aws_lambda_function.pdm_cw_emr_launcher.
       aws_default_region      = "eu-west-2"
       log_path                = "/var/log/adg/create_pdm_trigger.log"
+      skip_pdm_trigger        = local.skip_pdm_trigger_on_adg_completion[local.environment]
     }
   )
 }

--- a/steps.tf
+++ b/steps.tf
@@ -25,6 +25,7 @@ resource "aws_s3_bucket_object" "create_pdm_trigger_script" {
       aws_default_region      = "eu-west-2"
       log_path                = "/var/log/adg/create_pdm_trigger.log"
       skip_pdm_trigger        = local.skip_pdm_trigger_on_adg_completion[local.environment]
+      s3_prefix               = var.htme_data_location[local.environment]
     }
   )
 }

--- a/steps.tf
+++ b/steps.tf
@@ -16,6 +16,18 @@ resource "aws_s3_bucket_object" "generate_dataset_from_htme_script" {
   )
 }
 
+resource "aws_s3_bucket_object" "create_pdm_trigger_script" {
+  bucket = data.terraform_remote_state.common.outputs.config_bucket.id
+  key    = "component/analytical-dataset-generation/create_pdm_trigger.py"
+  content = templatefile("${path.module}/steps/create_pdm_trigger.py",
+    {
+      pdm_lambda_trigger_arn  = aws_lambda_function.pdm_cw_emr_launcher.
+      aws_default_region      = "eu-west-2"
+      log_path                = "/var/log/adg/create_pdm_trigger.log"
+    }
+  )
+}
+
 resource "aws_s3_bucket_object" "logger" {
   bucket  = data.terraform_remote_state.common.outputs.config_bucket.id
   key     = "component/analytical-dataset-generation/logger.py"

--- a/steps.tf
+++ b/steps.tf
@@ -21,7 +21,7 @@ resource "aws_s3_bucket_object" "create_pdm_trigger_script" {
   key    = "component/analytical-dataset-generation/create_pdm_trigger.py"
   content = templatefile("${path.module}/steps/create_pdm_trigger.py",
     {
-      pdm_lambda_trigger_arn  = aws_lambda_function.pdm_cw_emr_launcher.
+      pdm_lambda_trigger_arn  = aws_lambda_function.pdm_cw_emr_launcher.arn
       aws_default_region      = "eu-west-2"
       log_path                = "/var/log/adg/create_pdm_trigger.log"
       skip_pdm_trigger        = local.skip_pdm_trigger_on_adg_completion[local.environment]

--- a/steps/courtesy-flush.sh
+++ b/steps/courtesy-flush.sh
@@ -3,6 +3,7 @@
 CORRELATION_ID=$2
 S3_PREFIX=$4
 SNAPSHOT_TYPE=$6
+EXPORT_DATE=$8
 
 set -euo pipefail
 (
@@ -10,6 +11,7 @@ set -euo pipefail
     echo $CORRELATION_ID >>     /opt/emr/correlation_id.txt
     echo $S3_PREFIX >>          /opt/emr/s3_prefix.txt
     echo $SNAPSHOT_TYPE >>      /opt/emr/snapshot_type.txt
+    echo $EXPORT_DATE >>        /opt/emr/export_date.txt
 
     # Import the logging functions
     source /opt/emr/logging.sh

--- a/steps/create_pdm_trigger.py
+++ b/steps/create_pdm_trigger.py
@@ -77,6 +77,10 @@ def put_cloudwatch_event_target(client, now, rule_name):
     )
 
 
+def check_should_skip_step():
+    return should_skip_step(the_logger, "trigger-pdm")
+
+
 def should_step_be_skipped(now, do_not_trigger_after):
     if now > do_not_trigger_after:
         the_logger.info(
@@ -84,7 +88,7 @@ def should_step_be_skipped(now, do_not_trigger_after):
         )
         return True
 
-    if should_skip_step(the_logger, "trigger-pdm"):
+    if check_should_skip_step():
         the_logger.info(
             "Step needs to be skipped so will exit without error"
         )

--- a/steps/create_pdm_trigger.py
+++ b/steps/create_pdm_trigger.py
@@ -140,7 +140,6 @@ def should_step_be_skipped(skip_pdm_trigger, now, do_not_trigger_after):
         )
         return True
     
-
     return False
 
 

--- a/steps/create_pdm_trigger.py
+++ b/steps/create_pdm_trigger.py
@@ -1,0 +1,118 @@
+import boto3
+
+from datetime import datetime
+from steps.logger import setup_logging
+from steps.resume_step import should_skip_step
+
+the_logger = setup_logging(
+    log_level=os.environ["ADG_LOG_LEVEL"].upper()
+    if "ADG_LOG_LEVEL" in os.environ
+    else "INFO",
+    log_path="${log_path}",
+)
+
+
+def create_pdm_trigger(
+    publish_bucket, status_topic_arn, adg_param_key, skip_message_sending, sns_client=None, s3_client=None
+):
+    if exit_if_skipping_step(skip_message_sending):
+        return None
+
+    client = get_events_client()
+    now = datetime.now()
+    do_not_run_before = now.replace(hour=15, minute=00, second=00)
+    cron = get_cron(now, do_not_run_before)
+
+    rule_name = put_cloudwatch_event_rule(client, now, cron)
+    put_cloudwatch_event_target(client, now, rule_name)
+
+
+def get_events_client():
+    return boto3.client("events")
+
+
+def put_cloudwatch_event_rule(client, now, cron):
+    now_string = now.strftime("%d_%m_%Y_%H_%M_%S")
+    name = f"pdm_cw_emr_launcher_schedule_{now_string}"
+
+    the_logger.info(
+        f"Putting new cloudwatch event rule with name of '{name}' and cron of '{cron}'",
+    )
+
+    response = client.put_rule(
+        Name=name,
+        ScheduleExpression=cron,
+        State="ENABLED",
+        Description='Triggers PDM EMR Launcher',
+    )
+
+    the_logger.info(
+        f"Put new cloudwatch event rule",
+    )
+
+    return name
+
+
+def put_cloudwatch_event_target(client, now, rule_name):
+    now_string = now.strftime("%d_%m_%Y_%H_%M_%S")
+    id_string = f"pdm_cw_emr_launcher_target_{now_string}"
+
+    the_logger.info(
+        f"Putting new cloudwatch event target with id of '{id_string}'",
+    )
+
+    response = client.put_targets(
+        Rule=rule_name,
+        Targets=[
+            {
+                'Id': id_string,
+                'Arn': "${pdm_lambda_trigger_arn}",
+            },
+        ]
+    )
+
+    the_logger.info(
+        f"Put new cloudwatch event target",
+    )
+
+
+def should_step_be_skipped(now, do_not_trigger_after):
+    if now > do_not_trigger_after:
+        the_logger.info(
+            f"Skipping PDM triggering as datetime now '{now}' if after cut off of '{do_not_trigger_after}'",
+        )
+        return True
+
+    if should_skip_step(the_logger, "trigger-pdm"):
+        the_logger.info(
+            "Step needs to be skipped so will exit without error"
+        )
+        return True
+    
+
+    return False
+
+
+def get_cron(now, do_not_run_before):
+    if now < do_not_run_before:
+        cron = f"{do_not_run_before.minute} {do_not_run_before.hour} {do_not_run_before.day} {do_not_run_before.month} ? {do_not_run_before.year}"
+        the_logger.info(
+            "Time now is before cut off time so returning cut off time cron", cron,
+        )
+        return cron
+    
+    ten_minutes_from_now = now + datetime.timedelta(minutes = 5)
+    cron = f"{ten_minutes_from_now.minute} {ten_minutes_from_now.hour} {ten_minutes_from_now.day} {ten_minutes_from_now.month} ? {ten_minutes_from_now.year}"
+    the_logger.info(
+        "Time now is after cut off time so returning cron for 5 minutes time", cron,
+    )
+    return cron
+
+
+
+if __name__ == "__main__":
+    publish_bucket = "${publish_bucket}"
+    status_topic_arn = "${status_topic_arn}"
+    skip_message_sending = "${skip_message_sending}"
+    adg_param_key = "analytical-dataset/full/adg_output/adg_params.csv"
+    send_sns_message(publish_bucket, status_topic_arn, adg_param_key, skip_message_sending)

--- a/steps/create_pdm_trigger.py
+++ b/steps/create_pdm_trigger.py
@@ -31,8 +31,8 @@ def create_pdm_trigger(
     do_not_run_before = generate_do_not_run_before_date(EXPORT_DATE_FILE_NAME)
     cron = get_cron(now, do_not_run_before)
 
-    rule_name = put_cloudwatch_event_rule(client, now, cron)
-    put_cloudwatch_event_target(client, now, rule_name)
+    rule_name = put_cloudwatch_event_rule(events_client, now, cron)
+    put_cloudwatch_event_target(events_client, now, rule_name)
 
 
 def get_now():

--- a/steps/create_pdm_trigger.py
+++ b/steps/create_pdm_trigger.py
@@ -162,4 +162,4 @@ def get_cron(now, do_not_run_before):
 
 if __name__ == "__main__":
     skip_pdm_trigger = "${skip_pdm_trigger}"
-    send_sns_message(skip_pdm_trigger)
+    create_pdm_trigger(skip_pdm_trigger)

--- a/steps/create_pdm_trigger.py
+++ b/steps/create_pdm_trigger.py
@@ -49,7 +49,7 @@ def generate_cut_off_date(export_date_file):
     if not export_date:
         return None
 
-    export_date_parsed = datetime.strptime(date_time_str, '%Y-%m-%d')
+    export_date_parsed = datetime.strptime(export_date, '%Y-%m-%d')
     day_after_export_date = now + timedelta(days = 1)
 
     return day_after_export_date.replace(hour=3, minute=00, second=00)
@@ -65,7 +65,7 @@ def generate_do_not_run_before_date(export_date_file):
     if not export_date:
         return None
 
-    export_date_parsed = datetime.strptime(date_time_str, '%Y-%m-%d')
+    export_date_parsed = datetime.strptime(export_date, '%Y-%m-%d')
     return export_date_parsed.replace(hour=15, minute=00, second=00)
 
 

--- a/steps/create_pdm_trigger.py
+++ b/steps/create_pdm_trigger.py
@@ -44,7 +44,7 @@ def generate_cut_off_date(export_date_file):
         return None
 
     with open(export_date_file, "r") as f:
-        export_date = f.readlines().strip()
+        export_date = f.read().strip()
 
     if not export_date:
         return None
@@ -60,7 +60,7 @@ def generate_do_not_run_before_date(export_date_file):
         return None
 
     with open(export_date_file, "r") as f:
-        export_date = f.readlines().strip()
+        export_date = f.read().strip()
 
     if not export_date:
         return None

--- a/steps/create_pdm_trigger.py
+++ b/steps/create_pdm_trigger.py
@@ -80,7 +80,7 @@ def put_cloudwatch_event_rule(client, now, cron):
         f"Putting new cloudwatch event rule with name of '{name}' and cron of '{cron}'",
     )
 
-    response = client.put_rule(
+    client.put_rule(
         Name=name,
         ScheduleExpression=cron,
         State="ENABLED",
@@ -102,7 +102,7 @@ def put_cloudwatch_event_target(client, now, rule_name):
         f"Putting new cloudwatch event target with id of '{id_string}'",
     )
 
-    response = client.put_targets(
+    client.put_targets(
         Rule=rule_name,
         Targets=[
             {

--- a/steps/create_pdm_trigger.py
+++ b/steps/create_pdm_trigger.py
@@ -50,8 +50,7 @@ def generate_cut_off_date(export_date_file):
         return None
 
     export_date_parsed = datetime.strptime(export_date, '%Y-%m-%d')
-    day_after_export_date = now + timedelta(days = 1)
-
+    day_after_export_date = export_date_parsed + timedelta(days = 1)
     return day_after_export_date.replace(hour=3, minute=00, second=00)
 
 

--- a/steps/create_pdm_trigger.py
+++ b/steps/create_pdm_trigger.py
@@ -1,4 +1,5 @@
 import boto3
+import os
 
 from datetime import datetime
 from steps.logger import setup_logging

--- a/steps/create_pdm_trigger.py
+++ b/steps/create_pdm_trigger.py
@@ -100,14 +100,14 @@ def should_step_be_skipped(now, do_not_trigger_after):
 
 def get_cron(now, do_not_run_before):
     if now < do_not_run_before:
-        cron = f'{do_not_run_before.strftime("%M")} {do_not_run_before.strftime("%H")} {do_not_run_before.strftime("%d")} {do_not_run_before.strftime("%m")} ? {do_not_run_before.strftime("%y")}'
+        cron = f'{do_not_run_before.strftime("%M")} {do_not_run_before.strftime("%H")} {do_not_run_before.strftime("%d")} {do_not_run_before.strftime("%m")} ? {do_not_run_before.year}'
         the_logger.info(
             "Time now is before cut off time so returning cut off time cron", cron,
         )
         return cron
     
     ten_minutes_from_now = now + timedelta(minutes = 5)
-    cron = f'{ten_minutes_from_now.strftime("%M")} {ten_minutes_from_now.strftime("%H")} {ten_minutes_from_now.strftime("%d")} {ten_minutes_from_now.strftime("%m")} ? {ten_minutes_from_now.strftime("%y")}'
+    cron = f'{ten_minutes_from_now.strftime("%M")} {ten_minutes_from_now.strftime("%H")} {ten_minutes_from_now.strftime("%d")} {ten_minutes_from_now.strftime("%m")} ? {ten_minutes_from_now.year}'
     the_logger.info(
         "Time now is after cut off time so returning cron for 5 minutes time", cron,
     )

--- a/steps/create_pdm_trigger.py
+++ b/steps/create_pdm_trigger.py
@@ -96,14 +96,14 @@ def should_step_be_skipped(now, do_not_trigger_after):
 
 def get_cron(now, do_not_run_before):
     if now < do_not_run_before:
-        cron = f"{do_not_run_before.strftime("%M")} {do_not_run_before.strftime("%H")} {do_not_run_before.strftime("%d")} {do_not_run_before.strftime("%m")} ? {do_not_run_before.strftime("%y")}"
+        cron = f'{do_not_run_before.strftime("%M")} {do_not_run_before.strftime("%H")} {do_not_run_before.strftime("%d")} {do_not_run_before.strftime("%m")} ? {do_not_run_before.strftime("%y")}'
         the_logger.info(
             "Time now is before cut off time so returning cut off time cron", cron,
         )
         return cron
     
     ten_minutes_from_now = now + timedelta(minutes = 5)
-    cron = f"{ten_minutes_from_now.strftime("%M")} {ten_minutes_from_now.strftime("%H")} {ten_minutes_from_now.strftime("%d")} {ten_minutes_from_now.strftime("%m")} ? {ten_minutes_from_now.strftime("%y")}"
+    cron = f'{ten_minutes_from_now.strftime("%M")} {ten_minutes_from_now.strftime("%H")} {ten_minutes_from_now.strftime("%d")} {ten_minutes_from_now.strftime("%m")} ? {ten_minutes_from_now.strftime("%y")}'
     the_logger.info(
         "Time now is after cut off time so returning cron for 5 minutes time", cron,
     )

--- a/steps/create_pdm_trigger.py
+++ b/steps/create_pdm_trigger.py
@@ -1,7 +1,7 @@
 import boto3
 import os
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from steps.logger import setup_logging
 from steps.resume_step import should_skip_step
 
@@ -96,14 +96,14 @@ def should_step_be_skipped(now, do_not_trigger_after):
 
 def get_cron(now, do_not_run_before):
     if now < do_not_run_before:
-        cron = f"{do_not_run_before.minute} {do_not_run_before.hour} {do_not_run_before.day} {do_not_run_before.month} ? {do_not_run_before.year}"
+        cron = f"{do_not_run_before.strftime("%M")} {do_not_run_before.strftime("%H")} {do_not_run_before.strftime("%d")} {do_not_run_before.strftime("%m")} ? {do_not_run_before.strftime("%y")}"
         the_logger.info(
             "Time now is before cut off time so returning cut off time cron", cron,
         )
         return cron
     
-    ten_minutes_from_now = now + datetime.timedelta(minutes = 5)
-    cron = f"{ten_minutes_from_now.minute} {ten_minutes_from_now.hour} {ten_minutes_from_now.day} {ten_minutes_from_now.month} ? {ten_minutes_from_now.year}"
+    ten_minutes_from_now = now + timedelta(minutes = 5)
+    cron = f"{ten_minutes_from_now.strftime("%M")} {ten_minutes_from_now.strftime("%H")} {ten_minutes_from_now.strftime("%d")} {ten_minutes_from_now.strftime("%m")} ? {ten_minutes_from_now.strftime("%y")}"
     the_logger.info(
         "Time now is after cut off time so returning cron for 5 minutes time", cron,
     )

--- a/steps/create_pdm_trigger.py
+++ b/steps/create_pdm_trigger.py
@@ -48,7 +48,7 @@ def get_export_date(export_date_file):
     with open(export_date_file, "r") as f:
         export_date = f.read().strip()
 
-    return export_date
+    return export_date if export_date else None
 
 
 def generate_cut_off_date(export_date):

--- a/steps/create_pdm_trigger.py
+++ b/steps/create_pdm_trigger.py
@@ -82,7 +82,7 @@ def put_cloudwatch_event_rule(client, now, cron):
 
     client.put_rule(
         Name=name,
-        ScheduleExpression=cron,
+        ScheduleExpression=f"cron({cron})",
         State="ENABLED",
         Description='Triggers PDM EMR Launcher',
     )

--- a/steps/create_pdm_trigger.py
+++ b/steps/create_pdm_trigger.py
@@ -44,7 +44,7 @@ def generate_cut_off_date(export_date_file):
         return None
 
     with open(export_date_file, "r") as f:
-        export_date = f.readlines().split()
+        export_date = f.readlines().strip()
 
     if not export_date:
         return None
@@ -60,7 +60,7 @@ def generate_do_not_run_before_date(export_date_file):
         return None
 
     with open(export_date_file, "r") as f:
-        export_date = f.readlines().split()
+        export_date = f.readlines().strip()
 
     if not export_date:
         return None
@@ -149,14 +149,14 @@ def get_cron(now, do_not_run_before):
     if now < do_not_run_before:
         cron = f'{do_not_run_before.strftime("%M")} {do_not_run_before.strftime("%H")} {do_not_run_before.strftime("%d")} {do_not_run_before.strftime("%m")} ? {do_not_run_before.year}'
         the_logger.info(
-            "Time now is before cut off time so returning cut off time cron", cron,
+            f"Time now is before cut off time so returning cut off time cron of '{cron}' ",
         )
         return cron
     
     ten_minutes_from_now = now + timedelta(minutes = 5)
     cron = f'{ten_minutes_from_now.strftime("%M")} {ten_minutes_from_now.strftime("%H")} {ten_minutes_from_now.strftime("%d")} {ten_minutes_from_now.strftime("%m")} ? {ten_minutes_from_now.year}'
     the_logger.info(
-        "Time now is after cut off time so returning cron for 5 minutes time", cron,
+        f"Time now is after cut off time so returning cron of '{cron}' for 5 minutes time",
     )
     return cron
 

--- a/steps/send_notification.py
+++ b/steps/send_notification.py
@@ -37,7 +37,7 @@ def send_sns_message(
         reader = csv.reader(file)
         next(reader)
         for row in reader:
-            payload = {"correlation_id": row[0], "s3_prefix": row[1]}
+            payload = {"correlation_id": row[0], "s3_prefix": row[1], "snapshot_type": row[2], "export_date": row[3]}
     json_message = json.dumps(payload)
 
     sns_response = sns_client.publish(TopicArn=status_topic_arn, Message=json_message)

--- a/tests/test_generate_dataset_from_htme.py
+++ b/tests/test_generate_dataset_from_htme.py
@@ -39,6 +39,7 @@ SECRETS = "{'collections_all': {'db.core.contract': {'pii' : 'true', 'db' : 'cor
 SECRETS_COLLECTIONS = {DB_CORE_CONTRACT: {'pii' : 'true', 'db' : 'core', 'table' : 'contract'}}
 KEYS_MAP = {"test_ciphertext": "test_key"}
 RUN_TIME_STAMP = "2020-10-10_10-10-10"
+EXPORT_DATE = "2020-10-10"
 PUBLISHED_DATABASE_NAME = "test_db"
 CORRELATION_ID = "12345"
 AWS_REGION = "eu-west-2"
@@ -354,6 +355,7 @@ def mock_args():
     args.correlation_id = CORRELATION_ID
     args.s3_prefix = S3_PREFIX
     args.snapshot_type = SNAPSHOT_TYPE_FULL
+    args.export_date = EXPORT_DATE
     return args
 
 
@@ -410,6 +412,7 @@ def test_validate_required_args_with_invalid_values_for_snapshot_type():
     args = argparse.Namespace()
     args.correlation_id = CORRELATION_ID
     args.s3_prefix = S3_PREFIX
+    args.export_date = EXPORT_DATE
     args.snapshot_type = INVALID_SNAPSHOT_TYPE
     with pytest.raises(argparse.ArgumentError) as argument_error:
         generate_dataset_from_htme.validate_required_args(args)

--- a/tests/test_send_notification.py
+++ b/tests/test_send_notification.py
@@ -16,7 +16,7 @@ def test_send_sns_message():
     )
     s3_client = boto3.client(service_name="s3")
     s3_client.create_bucket(Bucket=PUBLISH_BUCKET)
-    test_data = b"CORRELATION_ID,S3_PREFIX\nabcd,analytical-dataset/2020-10-10"
+    test_data = b"CORRELATION_ID,S3_PREFIX\nabcd,analytical-dataset/2020-10-10,full,2020-01-01"
     s3_client.put_object(
         Body=test_data,
         Bucket=PUBLISH_BUCKET,

--- a/tests/test_trigger_pdm.py
+++ b/tests/test_trigger_pdm.py
@@ -1,0 +1,175 @@
+import boto3
+import unittest
+
+from steps import trigger_pdm
+from datetime import datetime
+
+
+# @mock_events
+# def test_send_sns_message():
+#     sns_client = boto3.client(service_name="sns", region_name=AWS_REGION)
+#     sns_client.create_topic(
+#         Name="status_topic", Attributes={"DisplayName": "test-topic"}
+#     )
+#     s3_client = boto3.client(service_name="s3")
+#     s3_client.create_bucket(Bucket=PUBLISH_BUCKET)
+#     test_data = b"CORRELATION_ID,S3_PREFIX\nabcd,analytical-dataset/2020-10-10"
+#     s3_client.put_object(
+#         Body=test_data,
+#         Bucket=PUBLISH_BUCKET,
+#         Key=ADG_PARAM_KEY,
+#     )
+
+#     topics_json = sns_client.list_topics()
+#     status_topic_arn = topics_json["Topics"][0]["TopicArn"]
+
+#     response = send_notification.send_sns_message(
+#         PUBLISH_BUCKET, status_topic_arn, ADG_PARAM_KEY, "false", sns_client, s3_client
+#     )
+
+#     assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+
+def test_put_cloudwatch_event_rule():
+    now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
+    cron = "1 1 1 1 1 1 1"
+    
+    events_client = mock.MagicMock()
+    events_client.put_rule = mock.MagicMock()
+
+    expected = "pdm_cw_emr_launcher_schedule_18_09_19_23_57_19"
+    actual = send_notification.put_cloudwatch_event_rule(
+        events_client, now, cron
+    )
+
+    events_client.put_rule.assert_called_once_with(
+        Name=expected,
+        ScheduleExpression=cron,
+        State="ENABLED",
+        Description='Triggers PDM EMR Launcher',
+    )
+
+    assert actual == expected
+
+
+def test_put_cloudwatch_event_target():
+    now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
+    id_string = "pdm_cw_emr_launcher_target_18_09_19_23_57_19"
+    rule_name = "pdm_cw_emr_launcher_schedule_18_09_19_23_57_19"
+
+    events_client = mock.MagicMock()
+    events_client.put_targets = mock.MagicMock()
+
+    actual = send_notification.put_cloudwatch_event_target(
+        events_client, now, cron
+    )
+
+    events_client.put_targets.assert_called_once_with(
+        Rule=rule_name,
+        Targets=[
+            {
+                'Id': id_string,
+                'Arn': "${pdm_lambda_trigger_arn}",
+            },
+        ]
+    )
+
+
+def test_should_skip_returns_true_when_after_cut_off(monkeypatch):
+    now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
+    do_not_trigger_after = datetime.strptime("18/09/19 22:55:19", '%d/%m/%y %H:%M:%S')
+
+    monkeypatch.setattr(
+        steps.resume_step, "should_skip_step", False
+    )
+
+    actual = trigger_pdm.should_step_be_skipped(
+        now, 
+        do_not_trigger_after
+    )
+
+    assert True == actual
+
+
+def test_should_skip_returns_true_when_after_cut_off_but_resume_step_returns_true(monkeypatch):
+    now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
+    do_not_trigger_after = datetime.strptime("18/09/19 23:59:19", '%d/%m/%y %H:%M:%S')
+
+    monkeypatch.setattr(
+        steps.resume_step, "should_skip_step", True
+    )
+
+    actual = trigger_pdm.should_step_be_skipped(
+        now, 
+        do_not_trigger_after
+    )
+
+    assert True == actual
+
+
+def test_should_skip_returns_false_when_before_cut_off_and_resume_step_returns_false(monkeypatch):
+    now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
+    do_not_trigger_after = datetime.strptime("18/09/19 23:59:19", '%d/%m/%y %H:%M:%S')
+
+    monkeypatch.setattr(
+        steps.resume_step, "should_skip_step", False
+    )
+
+    actual = trigger_pdm.should_step_be_skipped(
+        now, 
+        do_not_trigger_after
+    )
+
+    assert False == actual
+
+
+def test_get_cron_gives_cut_out_time_when_before_cut_off():
+    now = datetime.strptime("18/09/19 01:55:19", '%d/%m/%y %H:%M:%S')
+    do_not_run_before = datetime.strptime("18/09/19 02:55:19", '%d/%m/%y %H:%M:%S')
+
+    expected = "19 55 02 18 09 ? 19"
+    actual = trigger_pdm.get_cron(
+        now, 
+        do_not_run_before
+    )
+
+    assert expected == actual
+
+
+def test_get_cron_gives_now_plus_5_minutes_when_after_cut_off():
+    now = datetime.strptime("18/09/19 01:57:19", '%d/%m/%y %H:%M:%S')
+    do_not_run_before = datetime.strptime("18/09/19 00:55:19", '%d/%m/%y %H:%M:%S')
+
+    expected = "19 02 02 18 09 ? 19"
+    actual = trigger_pdm.get_cron(
+        now, 
+        do_not_run_before
+    )
+
+    assert expected == actual
+
+
+def test_get_cron_gives_cut_out_time_when_before_cut_off_over_date_boundary():
+    now = datetime.strptime("18/09/19 23:55:19", '%d/%m/%y %H:%M:%S')
+    do_not_run_before = datetime.strptime("19/09/19 01:55:19", '%d/%m/%y %H:%M:%S')
+
+    expected = "19 55 01 19 09 ? 19"
+    actual = trigger_pdm.get_cron(
+        now, 
+        do_not_run_before
+    )
+
+    assert expected == actual
+
+
+def test_get_cron_gives_now_plus_5_minutes_when_after_cut_off_over_date_boundary():
+    now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
+    do_not_run_before = datetime.strptime("18/09/19 22:55:19", '%d/%m/%y %H:%M:%S')
+
+    expected = "19 02 00 19 09 ? 19"
+    actual = trigger_pdm.get_cron(
+        now, 
+        do_not_run_before
+    )
+
+    assert expected == actual

--- a/tests/test_trigger_pdm.py
+++ b/tests/test_trigger_pdm.py
@@ -33,6 +33,9 @@ class TestReplayer(unittest.TestCase):
         do_not_run_before = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
         cron = "test cron"
         rule_name = "test rule"
+        
+        events_client = mock.MagicMock()
+        events_client.put_rule = mock.MagicMock()
 
         get_now_mock.return_value = now
         generate_cut_off_date_mock.return_value = do_not_run_after
@@ -100,7 +103,7 @@ class TestReplayer(unittest.TestCase):
         response = create_pdm_trigger.create_pdm_trigger(
             "true", 
         )
-        
+
         get_now_mock.assert_called_once()
         generate_cut_off_date_mock.assert_called_once()
         should_step_be_skipped_mock.assert_called_once_with(

--- a/tests/test_trigger_pdm.py
+++ b/tests/test_trigger_pdm.py
@@ -202,7 +202,7 @@ class TestReplayer(unittest.TestCase):
 
     def test_put_cloudwatch_event_rule(self):
         now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
-        cron = "1 1 1 1 1 1 1"
+        cron = "1 1 1 1 1 1"
         
         events_client = mock.MagicMock()
         events_client.put_rule = mock.MagicMock()
@@ -214,7 +214,7 @@ class TestReplayer(unittest.TestCase):
 
         events_client.put_rule.assert_called_once_with(
             Name=expected,
-            ScheduleExpression=cron,
+            ScheduleExpression="cron(1 1 1 1 1 1)",
             State="ENABLED",
             Description='Triggers PDM EMR Launcher',
         )

--- a/tests/test_trigger_pdm.py
+++ b/tests/test_trigger_pdm.py
@@ -83,7 +83,7 @@ def test_should_skip_returns_true_when_after_cut_off(monkeypatch):
     do_not_trigger_after = datetime.strptime("18/09/19 22:55:19", '%d/%m/%y %H:%M:%S')
 
     monkeypatch.setattr(
-        steps.create_pdm_trigger, "check_should_skip_step", False
+        steps.create_pdm_trigger, "check_should_skip_step", return_false
     )
 
     actual = create_pdm_trigger.should_step_be_skipped(
@@ -99,7 +99,7 @@ def test_should_skip_returns_true_when_after_cut_off_but_resume_step_returns_tru
     do_not_trigger_after = datetime.strptime("18/09/19 23:59:19", '%d/%m/%y %H:%M:%S')
 
     monkeypatch.setattr(
-        steps.create_pdm_trigger, "check_should_skip_step", True
+        steps.create_pdm_trigger, "check_should_skip_step", return_true
     )
 
     actual = create_pdm_trigger.should_step_be_skipped(
@@ -115,7 +115,7 @@ def test_should_skip_returns_false_when_before_cut_off_and_resume_step_returns_f
     do_not_trigger_after = datetime.strptime("18/09/19 23:59:19", '%d/%m/%y %H:%M:%S')
 
     monkeypatch.setattr(
-        steps.create_pdm_trigger, "check_should_skip_step", False
+        steps.create_pdm_trigger, "check_should_skip_step", return_false
     )
 
     actual = create_pdm_trigger.should_step_be_skipped(
@@ -176,3 +176,11 @@ def test_get_cron_gives_now_plus_5_minutes_when_after_cut_off_over_date_boundary
     )
 
     assert expected == actual
+
+
+def return_true:
+    return True
+
+
+def return_false:
+    return False

--- a/tests/test_trigger_pdm.py
+++ b/tests/test_trigger_pdm.py
@@ -83,7 +83,7 @@ def test_should_skip_returns_true_when_after_cut_off(monkeypatch):
     do_not_trigger_after = datetime.strptime("18/09/19 22:55:19", '%d/%m/%y %H:%M:%S')
 
     monkeypatch.setattr(
-        steps.resume_step, "should_skip_step", False
+        steps.create_pdm_trigger, "check_should_skip_step", False
     )
 
     actual = create_pdm_trigger.should_step_be_skipped(
@@ -99,7 +99,7 @@ def test_should_skip_returns_true_when_after_cut_off_but_resume_step_returns_tru
     do_not_trigger_after = datetime.strptime("18/09/19 23:59:19", '%d/%m/%y %H:%M:%S')
 
     monkeypatch.setattr(
-        steps.resume_step, "should_skip_step", True
+        steps.create_pdm_trigger, "check_should_skip_step", True
     )
 
     actual = create_pdm_trigger.should_step_be_skipped(
@@ -115,7 +115,7 @@ def test_should_skip_returns_false_when_before_cut_off_and_resume_step_returns_f
     do_not_trigger_after = datetime.strptime("18/09/19 23:59:19", '%d/%m/%y %H:%M:%S')
 
     monkeypatch.setattr(
-        steps.resume_step, "should_skip_step", False
+        steps.create_pdm_trigger, "check_should_skip_step", False
     )
 
     actual = create_pdm_trigger.should_step_be_skipped(
@@ -130,7 +130,7 @@ def test_get_cron_gives_cut_out_time_when_before_cut_off():
     now = datetime.strptime("18/09/19 01:55:19", '%d/%m/%y %H:%M:%S')
     do_not_run_before = datetime.strptime("18/09/19 02:55:19", '%d/%m/%y %H:%M:%S')
 
-    expected = "19 55 02 18 09 ? 2019"
+    expected = "55 02 18 09 ? 2019"
     actual = create_pdm_trigger.get_cron(
         now, 
         do_not_run_before
@@ -143,7 +143,7 @@ def test_get_cron_gives_now_plus_5_minutes_when_after_cut_off():
     now = datetime.strptime("18/09/19 01:57:19", '%d/%m/%y %H:%M:%S')
     do_not_run_before = datetime.strptime("18/09/19 00:55:19", '%d/%m/%y %H:%M:%S')
 
-    expected = "19 02 02 18 09 ? 2019"
+    expected = "02 02 18 09 ? 2019"
     actual = create_pdm_trigger.get_cron(
         now, 
         do_not_run_before
@@ -156,7 +156,7 @@ def test_get_cron_gives_cut_out_time_when_before_cut_off_over_date_boundary():
     now = datetime.strptime("18/09/19 23:55:19", '%d/%m/%y %H:%M:%S')
     do_not_run_before = datetime.strptime("19/09/19 01:55:19", '%d/%m/%y %H:%M:%S')
 
-    expected = "19 55 01 19 09 ? 2019"
+    expected = "55 01 19 09 ? 2019"
     actual = create_pdm_trigger.get_cron(
         now, 
         do_not_run_before
@@ -169,7 +169,7 @@ def test_get_cron_gives_now_plus_5_minutes_when_after_cut_off_over_date_boundary
     now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
     do_not_run_before = datetime.strptime("18/09/19 22:55:19", '%d/%m/%y %H:%M:%S')
 
-    expected = "19 02 00 19 09 ? 2019"
+    expected = "02 00 19 09 ? 2019"
     actual = create_pdm_trigger.get_cron(
         now, 
         do_not_run_before

--- a/tests/test_trigger_pdm.py
+++ b/tests/test_trigger_pdm.py
@@ -17,7 +17,7 @@ class TestReplayer(unittest.TestCase):
     @mock.patch("steps.create_pdm_trigger.get_events_client")
     @mock.patch("steps.create_pdm_trigger.should_step_be_skipped")
     @mock.patch("steps.create_pdm_trigger.generate_cut_off_date")
-    @mock.patch("steps.create_pdm_trigger.get_now")
+    @mock.patch("create_pdm_trigger.get_now")
     def test_create_pdm_trigger(
         self,
         get_now_mock,

--- a/tests/test_trigger_pdm.py
+++ b/tests/test_trigger_pdm.py
@@ -178,9 +178,9 @@ def test_get_cron_gives_now_plus_5_minutes_when_after_cut_off_over_date_boundary
     assert expected == actual
 
 
-def return_true:
+def return_true():
     return True
 
 
-def return_false:
+def return_false():
     return False

--- a/tests/test_trigger_pdm.py
+++ b/tests/test_trigger_pdm.py
@@ -129,7 +129,7 @@ def test_generate_cut_off_date():
     with open(export_date_file, "wt") as f:
         export_date = f.write(export_date)
 
-    expected = datetime.strptime("21/10/2020 03:00:00", '%d/%m/%y %H:%M:%S')"
+    expected = datetime.strptime("21/10/2020 03:00:00", '%d/%m/%y %H:%M:%S')
     actual = create_pdm_trigger.generate_cut_off_date(export_date_file)
 
     assert actual == expected

--- a/tests/test_trigger_pdm.py
+++ b/tests/test_trigger_pdm.py
@@ -1,7 +1,7 @@
 import boto3
 import unittest
 
-from steps import trigger_pdm
+from steps import create_pdm_trigger
 from datetime import datetime
 
 
@@ -38,7 +38,7 @@ def test_put_cloudwatch_event_rule():
     events_client.put_rule = mock.MagicMock()
 
     expected = "pdm_cw_emr_launcher_schedule_18_09_19_23_57_19"
-    actual = send_notification.put_cloudwatch_event_rule(
+    actual = create_pdm_trigger.put_cloudwatch_event_rule(
         events_client, now, cron
     )
 
@@ -60,7 +60,7 @@ def test_put_cloudwatch_event_target():
     events_client = mock.MagicMock()
     events_client.put_targets = mock.MagicMock()
 
-    actual = send_notification.put_cloudwatch_event_target(
+    actual = create_pdm_trigger.put_cloudwatch_event_target(
         events_client, now, cron
     )
 
@@ -83,7 +83,7 @@ def test_should_skip_returns_true_when_after_cut_off(monkeypatch):
         steps.resume_step, "should_skip_step", False
     )
 
-    actual = trigger_pdm.should_step_be_skipped(
+    actual = create_pdm_trigger.should_step_be_skipped(
         now, 
         do_not_trigger_after
     )
@@ -99,7 +99,7 @@ def test_should_skip_returns_true_when_after_cut_off_but_resume_step_returns_tru
         steps.resume_step, "should_skip_step", True
     )
 
-    actual = trigger_pdm.should_step_be_skipped(
+    actual = create_pdm_trigger.should_step_be_skipped(
         now, 
         do_not_trigger_after
     )
@@ -115,7 +115,7 @@ def test_should_skip_returns_false_when_before_cut_off_and_resume_step_returns_f
         steps.resume_step, "should_skip_step", False
     )
 
-    actual = trigger_pdm.should_step_be_skipped(
+    actual = create_pdm_trigger.should_step_be_skipped(
         now, 
         do_not_trigger_after
     )
@@ -128,7 +128,7 @@ def test_get_cron_gives_cut_out_time_when_before_cut_off():
     do_not_run_before = datetime.strptime("18/09/19 02:55:19", '%d/%m/%y %H:%M:%S')
 
     expected = "19 55 02 18 09 ? 19"
-    actual = trigger_pdm.get_cron(
+    actual = create_pdm_trigger.get_cron(
         now, 
         do_not_run_before
     )
@@ -141,7 +141,7 @@ def test_get_cron_gives_now_plus_5_minutes_when_after_cut_off():
     do_not_run_before = datetime.strptime("18/09/19 00:55:19", '%d/%m/%y %H:%M:%S')
 
     expected = "19 02 02 18 09 ? 19"
-    actual = trigger_pdm.get_cron(
+    actual = create_pdm_trigger.get_cron(
         now, 
         do_not_run_before
     )
@@ -154,7 +154,7 @@ def test_get_cron_gives_cut_out_time_when_before_cut_off_over_date_boundary():
     do_not_run_before = datetime.strptime("19/09/19 01:55:19", '%d/%m/%y %H:%M:%S')
 
     expected = "19 55 01 19 09 ? 19"
-    actual = trigger_pdm.get_cron(
+    actual = create_pdm_trigger.get_cron(
         now, 
         do_not_run_before
     )
@@ -167,7 +167,7 @@ def test_get_cron_gives_now_plus_5_minutes_when_after_cut_off_over_date_boundary
     do_not_run_before = datetime.strptime("18/09/19 22:55:19", '%d/%m/%y %H:%M:%S')
 
     expected = "19 02 00 19 09 ? 19"
-    actual = trigger_pdm.get_cron(
+    actual = create_pdm_trigger.get_cron(
         now, 
         do_not_run_before
     )

--- a/tests/test_trigger_pdm.py
+++ b/tests/test_trigger_pdm.py
@@ -89,7 +89,7 @@ def test_generate_do_not_run_before_date():
     with open(export_date_file, "wt") as f:
         export_date = f.write(export_date)
 
-    expected = datetime.strptime("20/10/2020 15:00:00", '%d/%m/%y %H:%M:%S')"
+    expected = datetime.strptime("20/10/2020 15:00:00", '%d/%m/%y %H:%M:%S')
     actual = create_pdm_trigger.generate_do_not_run_before_date(export_date_file)
 
     assert actual == expected

--- a/tests/test_trigger_pdm.py
+++ b/tests/test_trigger_pdm.py
@@ -64,7 +64,7 @@ def test_put_cloudwatch_event_target():
     events_client.put_targets = mock.MagicMock()
 
     actual = create_pdm_trigger.put_cloudwatch_event_target(
-        events_client, now, cron
+        events_client, now, rule_name
     )
 
     events_client.put_targets.assert_called_once_with(

--- a/tests/test_trigger_pdm.py
+++ b/tests/test_trigger_pdm.py
@@ -1,5 +1,6 @@
 import boto3
 import unittest
+import os
 
 from steps import create_pdm_trigger
 from datetime import datetime

--- a/tests/test_trigger_pdm.py
+++ b/tests/test_trigger_pdm.py
@@ -230,6 +230,9 @@ class TestReplayer(unittest.TestCase):
                 {
                     'Id': id_string,
                     'Arn': "${pdm_lambda_trigger_arn}",
+                    'Input': {
+                        'export_date': EXPORT_DATE,
+                    }
                 },
             ]
         )

--- a/tests/test_trigger_pdm.py
+++ b/tests/test_trigger_pdm.py
@@ -19,8 +19,8 @@ class TestReplayer(unittest.TestCase):
     @mock.patch("steps.create_pdm_trigger.generate_do_not_run_before_date")
     @mock.patch("steps.create_pdm_trigger.get_events_client")
     @mock.patch("steps.create_pdm_trigger.should_step_be_skipped")
-    @mock.patch("steps.create_pdm_trigger.get_export_date")
     @mock.patch("steps.create_pdm_trigger.generate_cut_off_date")
+    @mock.patch("steps.create_pdm_trigger.get_export_date")
     @mock.patch("steps.create_pdm_trigger.get_now")
     def test_create_pdm_trigger(
         self,

--- a/tests/test_trigger_pdm.py
+++ b/tests/test_trigger_pdm.py
@@ -82,7 +82,7 @@ class TestReplayer(unittest.TestCase):
         )
 
 
-    def test_generate_do_not_run_before_date():
+    def test_generate_do_not_run_before_date(self):
         export_date = "2020-10-20"
         export_date_file = "/tmp/test.txt"
         if os.path.isfile(export_date_file):

--- a/tests/test_trigger_pdm.py
+++ b/tests/test_trigger_pdm.py
@@ -58,7 +58,7 @@ def test_create_pdm_trigger(
     get_now_mock.assert_called_once()
     generate_cut_off_date_mock.assert_called_once()
     should_step_be_skipped_mock.assert_called_once_with(
-        False,
+        "false",
         now,
         do_not_run_after,
     )
@@ -83,7 +83,7 @@ def test_create_pdm_trigger(
 def test_generate_do_not_run_before_date():
     export_date = "2020-10-20"
     export_date_file = "/tmp/test.txt"
-    if not os.path.isfile(export_date_file):
+    if os.path.isfile(export_date_file):
         os.remove(export_date_file)
 
     with open(export_date_file, "wt") as f:
@@ -97,7 +97,7 @@ def test_generate_do_not_run_before_date():
 
 def test_generate_do_not_run_before_date_when_no_file():
     export_date_file = "/tmp/test.txt"
-    if not os.path.isfile(export_date_file):
+    if os.path.isfile(export_date_file):
         os.remove(export_date_file)
 
     expected = None
@@ -108,7 +108,7 @@ def test_generate_do_not_run_before_date_when_no_file():
 
 def test_generate_do_not_run_before_date_when_empty_file():
     export_date_file = "/tmp/test.txt"
-    if not os.path.isfile(export_date_file):
+    if os.path.isfile(export_date_file):
         os.remove(export_date_file)
 
     with open(export_date_file, "wt") as f:
@@ -123,7 +123,7 @@ def test_generate_do_not_run_before_date_when_empty_file():
 def test_generate_cut_off_date():
     export_date = "2020-10-20"
     export_date_file = "/tmp/test.txt"
-    if not os.path.isfile(export_date_file):
+    if os.path.isfile(export_date_file):
         os.remove(export_date_file)
 
     with open(export_date_file, "wt") as f:
@@ -137,7 +137,7 @@ def test_generate_cut_off_date():
 
 def test_generate_cut_off_date_when_no_file():
     export_date_file = "/tmp/test.txt"
-    if not os.path.isfile(export_date_file):
+    if os.path.isfile(export_date_file):
         os.remove(export_date_file)
 
     expected = None
@@ -148,7 +148,7 @@ def test_generate_cut_off_date_when_no_file():
 
 def test_generate_cut_off_date_when_empty_file():
     export_date_file = "/tmp/test.txt"
-    if not os.path.isfile(export_date_file):
+    if os.path.isfile(export_date_file):
         os.remove(export_date_file)
 
     with open(export_date_file, "wt") as f:
@@ -214,7 +214,7 @@ def test_should_skip_returns_true_when_after_cut_off(monkeypatch):
     )
 
     actual = create_pdm_trigger.should_step_be_skipped(
-        False,
+        "false",
         now, 
         do_not_trigger_after
     )
@@ -231,7 +231,7 @@ def test_should_skip_returns_true_when_after_cut_off_but_resume_step_returns_tru
     )
 
     actual = create_pdm_trigger.should_step_be_skipped(
-        False,
+        "false",
         now, 
         do_not_trigger_after
     )
@@ -248,7 +248,7 @@ def test_should_skip_returns_false_when_before_cut_off_and_resume_step_returns_f
     )
 
     actual = create_pdm_trigger.should_step_be_skipped(
-        False,
+        "false",
         now, 
         do_not_trigger_after
     )
@@ -265,7 +265,24 @@ def test_should_skip_returns_true_when_skip_setting_set_to_true(monkeypatch):
     )
 
     actual = create_pdm_trigger.should_step_be_skipped(
-        True,
+        "true",
+        now, 
+        do_not_trigger_after
+    )
+
+    assert True == actual
+
+
+def test_should_skip_returns_true_when_skip_setting_set_to_true_upper_case(monkeypatch):
+    now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
+    do_not_trigger_after = datetime.strptime("18/09/19 23:59:19", '%d/%m/%y %H:%M:%S')
+
+    monkeypatch.setattr(
+        steps.create_pdm_trigger, "check_should_skip_step", return_false
+    )
+
+    actual = create_pdm_trigger.should_step_be_skipped(
+        "TRUE",
         now, 
         do_not_trigger_after
     )

--- a/tests/test_trigger_pdm.py
+++ b/tests/test_trigger_pdm.py
@@ -3,6 +3,7 @@ import unittest
 import os
 import pytest
 import json
+import argparse
 
 from steps import create_pdm_trigger
 from datetime import datetime

--- a/tests/test_trigger_pdm.py
+++ b/tests/test_trigger_pdm.py
@@ -7,6 +7,8 @@ from steps import create_pdm_trigger
 from datetime import datetime
 from unittest import mock
 
+TMP_TEST_FILE = "/tmp/test.txt"
+
 
 class TestReplayer(unittest.TestCase):
     @mock.patch("steps.create_pdm_trigger.put_cloudwatch_event_target")
@@ -45,7 +47,7 @@ class TestReplayer(unittest.TestCase):
         get_cron_mock.return_value = cron
         put_cloudwatch_event_rule_mock.return_value = rule_name
         
-        response = create_pdm_trigger.create_pdm_trigger(
+        create_pdm_trigger.create_pdm_trigger(
             "false", 
         )
         
@@ -100,7 +102,7 @@ class TestReplayer(unittest.TestCase):
         generate_cut_off_date_mock.return_value = do_not_run_after
         should_step_be_skipped_mock.return_value = True
         
-        response = create_pdm_trigger.create_pdm_trigger(
+        create_pdm_trigger.create_pdm_trigger(
             "true", 
         )
 
@@ -120,7 +122,7 @@ class TestReplayer(unittest.TestCase):
 
     def test_generate_do_not_run_before_date(self):
         export_date = "2020-10-20"
-        export_date_file = "/tmp/test.txt"
+        export_date_file =TMP_TEST_FILE
         if os.path.isfile(export_date_file):
             os.remove(export_date_file)
 
@@ -134,7 +136,7 @@ class TestReplayer(unittest.TestCase):
 
 
     def test_generate_do_not_run_before_date_when_no_file(self):
-        export_date_file = "/tmp/test.txt"
+        export_date_file = TMP_TEST_FILE
         if os.path.isfile(export_date_file):
             os.remove(export_date_file)
 
@@ -145,12 +147,12 @@ class TestReplayer(unittest.TestCase):
 
 
     def test_generate_do_not_run_before_date_when_empty_file(self):
-        export_date_file = "/tmp/test.txt"
+        export_date_file = TMP_TEST_FILE
         if os.path.isfile(export_date_file):
             os.remove(export_date_file)
 
         with open(export_date_file, "wt") as f:
-            export_date = f.write("")
+            f.write("")
 
         expected = None
         actual = create_pdm_trigger.generate_do_not_run_before_date(export_date_file)
@@ -160,12 +162,12 @@ class TestReplayer(unittest.TestCase):
 
     def test_generate_cut_off_date(self):
         export_date = "2020-10-20"
-        export_date_file = "/tmp/test.txt"
+        export_date_file = TMP_TEST_FILE
         if os.path.isfile(export_date_file):
             os.remove(export_date_file)
 
         with open(export_date_file, "wt") as f:
-            export_date = f.write(export_date)
+            f.write(export_date)
 
         expected = datetime.strptime("21/10/2020 03:00:00", '%d/%m/%Y %H:%M:%S')
         actual = create_pdm_trigger.generate_cut_off_date(export_date_file)
@@ -174,7 +176,7 @@ class TestReplayer(unittest.TestCase):
 
 
     def test_generate_cut_off_date_when_no_file(self):
-        export_date_file = "/tmp/test.txt"
+        export_date_file = TMP_TEST_FILE
         if os.path.isfile(export_date_file):
             os.remove(export_date_file)
 
@@ -185,12 +187,12 @@ class TestReplayer(unittest.TestCase):
 
 
     def test_generate_cut_off_date_when_empty_file(self):
-        export_date_file = "/tmp/test.txt"
+        export_date_file = TMP_TEST_FILE
         if os.path.isfile(export_date_file):
             os.remove(export_date_file)
 
         with open(export_date_file, "wt") as f:
-            export_date = f.write("")
+            f.write("")
 
         expected = None
         actual = create_pdm_trigger.generate_cut_off_date(export_date_file)
@@ -228,7 +230,7 @@ class TestReplayer(unittest.TestCase):
         events_client = mock.MagicMock()
         events_client.put_targets = mock.MagicMock()
 
-        actual = create_pdm_trigger.put_cloudwatch_event_target(
+        create_pdm_trigger.put_cloudwatch_event_target(
             events_client, now, rule_name
         )
 

--- a/tests/test_trigger_pdm.py
+++ b/tests/test_trigger_pdm.py
@@ -2,353 +2,358 @@ import boto3
 import unittest
 import os
 import steps
+import pytest
 
 from steps import create_pdm_trigger
 from datetime import datetime
 from unittest import mock
 
 
-@mock.patch("steps.create_pdm_trigger.put_cloudwatch_event_target")
-@mock.patch("steps.create_pdm_trigger.put_cloudwatch_event_rule")
-@mock.patch("steps.create_pdm_trigger.get_cron")
-@mock.patch("steps.create_pdm_trigger.generate_do_not_run_before_date")
-@mock.patch("steps.create_pdm_trigger.get_events_client")
-@mock.patch("steps.create_pdm_trigger.should_step_be_skipped")
-@mock.patch("steps.create_pdm_trigger.generate_cut_off_date")
-@mock.patch("steps.create_pdm_trigger.get_now")
-def test_create_pdm_trigger(
-    self,
-    get_now_mock,
-    generate_cut_off_date_mock,
-    should_step_be_skipped_mock,
-    get_events_client_mock,
-    generate_do_not_run_before_date_mock,
-    get_cron_mock,
-    put_cloudwatch_event_rule_mock,
-    put_cloudwatch_event_target_mock,
-):
-    now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
-    do_not_run_after = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
-    do_not_run_before = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
-    cron = "test cron"
-    rule_name = "test rule"
-
-    events_client = mock.MagicMock()
-    get_now_mock = mock.MagicMock()
-    generate_cut_off_date_mock = mock.MagicMock()
-    should_step_be_skipped_mock = mock.MagicMock()
-    get_events_client_mock = mock.MagicMock()
-    generate_do_not_run_before_date_mock = mock.MagicMock()
-    get_cron_mock = mock.MagicMock()
-    put_cloudwatch_event_rule_mock = mock.MagicMock()
-    put_cloudwatch_event_target_mock = mock.MagicMock()
-
-    get_now_mock.return_value = now
-    generate_cut_off_date_mock.return_value = do_not_run_after
-    should_step_be_skipped_mock.return_value = False
-    get_events_client_mock.return_value = events_client
-    generate_do_not_run_before_date_mock.return_value = do_not_run_before
-    get_cron_mock.return_value = cron
-    put_cloudwatch_event_rule_mock.return_value = rule_name
-    
-    response = send_notification.create_pdm_trigger(
-        False, 
-    )
-    
-    get_now_mock.assert_called_once()
-    generate_cut_off_date_mock.assert_called_once()
-    should_step_be_skipped_mock.assert_called_once_with(
-        "false",
-        now,
-        do_not_run_after,
-    )
-    get_events_client_mock.assert_called_once()
-    generate_do_not_run_before_date_mock.assert_called_once()
-    get_cron_mock.assert_called_once_with(
-        now,
-        do_not_run_before,
-    )
-    put_cloudwatch_event_rule_mock.assert_called_once_with(
-        events_client,
-        now,
-        cron,
-    )
-    put_cloudwatch_event_target_mock.assert_called_once_with(
-        events_client,
-        now,
-        rule_name,
-    )
-
-
-def test_generate_do_not_run_before_date():
-    export_date = "2020-10-20"
-    export_date_file = "/tmp/test.txt"
-    if os.path.isfile(export_date_file):
-        os.remove(export_date_file)
-
-    with open(export_date_file, "wt") as f:
-        export_date = f.write(export_date)
-
-    expected = datetime.strptime("20/10/2020 15:00:00", '%d/%m/%Y %H:%M:%S')
-    actual = create_pdm_trigger.generate_do_not_run_before_date(export_date_file)
-
-    assert actual == expected
-
-
-def test_generate_do_not_run_before_date_when_no_file():
-    export_date_file = "/tmp/test.txt"
-    if os.path.isfile(export_date_file):
-        os.remove(export_date_file)
-
-    expected = None
-    actual = create_pdm_trigger.generate_do_not_run_before_date(export_date_file)
-
-    assert actual == expected
-
-
-def test_generate_do_not_run_before_date_when_empty_file():
-    export_date_file = "/tmp/test.txt"
-    if os.path.isfile(export_date_file):
-        os.remove(export_date_file)
+class TestReplayer(unittest.TestCase):
+    @mock.patch("steps.create_pdm_trigger.put_cloudwatch_event_target")
+    @mock.patch("steps.create_pdm_trigger.put_cloudwatch_event_rule")
+    @mock.patch("steps.create_pdm_trigger.get_cron")
+    @mock.patch("steps.create_pdm_trigger.generate_do_not_run_before_date")
+    @mock.patch("steps.create_pdm_trigger.get_events_client")
+    @mock.patch("steps.create_pdm_trigger.should_step_be_skipped")
+    @mock.patch("steps.create_pdm_trigger.generate_cut_off_date")
+    @mock.patch("steps.create_pdm_trigger.get_now")
+    def test_create_pdm_trigger(
+        self,
+        get_now_mock,
+        generate_cut_off_date_mock,
+        should_step_be_skipped_mock,
+        get_events_client_mock,
+        generate_do_not_run_before_date_mock,
+        get_cron_mock,
+        put_cloudwatch_event_rule_mock,
+        put_cloudwatch_event_target_mock,
+    ):
+        now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
+        do_not_run_after = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
+        do_not_run_before = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
+        cron = "test cron"
+        rule_name = "test rule"
+
+        events_client = mock.MagicMock()
+        get_now_mock = mock.MagicMock()
+        generate_cut_off_date_mock = mock.MagicMock()
+        should_step_be_skipped_mock = mock.MagicMock()
+        get_events_client_mock = mock.MagicMock()
+        generate_do_not_run_before_date_mock = mock.MagicMock()
+        get_cron_mock = mock.MagicMock()
+        put_cloudwatch_event_rule_mock = mock.MagicMock()
+        put_cloudwatch_event_target_mock = mock.MagicMock()
+
+        get_now_mock.return_value = now
+        generate_cut_off_date_mock.return_value = do_not_run_after
+        should_step_be_skipped_mock.return_value = False
+        get_events_client_mock.return_value = events_client
+        generate_do_not_run_before_date_mock.return_value = do_not_run_before
+        get_cron_mock.return_value = cron
+        put_cloudwatch_event_rule_mock.return_value = rule_name
+        
+        response = send_notification.create_pdm_trigger(
+            False, 
+        )
+        
+        get_now_mock.assert_called_once()
+        generate_cut_off_date_mock.assert_called_once()
+        should_step_be_skipped_mock.assert_called_once_with(
+            "false",
+            now,
+            do_not_run_after,
+        )
+        get_events_client_mock.assert_called_once()
+        generate_do_not_run_before_date_mock.assert_called_once()
+        get_cron_mock.assert_called_once_with(
+            now,
+            do_not_run_before,
+        )
+        put_cloudwatch_event_rule_mock.assert_called_once_with(
+            events_client,
+            now,
+            cron,
+        )
+        put_cloudwatch_event_target_mock.assert_called_once_with(
+            events_client,
+            now,
+            rule_name,
+        )
+
+
+    def test_generate_do_not_run_before_date():
+        export_date = "2020-10-20"
+        export_date_file = "/tmp/test.txt"
+        if os.path.isfile(export_date_file):
+            os.remove(export_date_file)
+
+        with open(export_date_file, "wt") as f:
+            export_date = f.write(export_date)
+
+        expected = datetime.strptime("20/10/2020 15:00:00", '%d/%m/%Y %H:%M:%S')
+        actual = create_pdm_trigger.generate_do_not_run_before_date(export_date_file)
+
+        assert actual == expected
+
+
+    def test_generate_do_not_run_before_date_when_no_file():
+        export_date_file = "/tmp/test.txt"
+        if os.path.isfile(export_date_file):
+            os.remove(export_date_file)
+
+        expected = None
+        actual = create_pdm_trigger.generate_do_not_run_before_date(export_date_file)
+
+        assert actual == expected
+
+
+    def test_generate_do_not_run_before_date_when_empty_file():
+        export_date_file = "/tmp/test.txt"
+        if os.path.isfile(export_date_file):
+            os.remove(export_date_file)
 
-    with open(export_date_file, "wt") as f:
-        export_date = f.write("")
+        with open(export_date_file, "wt") as f:
+            export_date = f.write("")
 
-    expected = None
-    actual = create_pdm_trigger.generate_do_not_run_before_date(export_date_file)
+        expected = None
+        actual = create_pdm_trigger.generate_do_not_run_before_date(export_date_file)
 
-    assert actual == expected
+        assert actual == expected
 
 
-def test_generate_cut_off_date():
-    export_date = "2020-10-20"
-    export_date_file = "/tmp/test.txt"
-    if os.path.isfile(export_date_file):
-        os.remove(export_date_file)
+    def test_generate_cut_off_date():
+        export_date = "2020-10-20"
+        export_date_file = "/tmp/test.txt"
+        if os.path.isfile(export_date_file):
+            os.remove(export_date_file)
 
-    with open(export_date_file, "wt") as f:
-        export_date = f.write(export_date)
+        with open(export_date_file, "wt") as f:
+            export_date = f.write(export_date)
 
-    expected = datetime.strptime("21/10/2020 03:00:00", '%d/%m/%Y %H:%M:%S')
-    actual = create_pdm_trigger.generate_cut_off_date(export_date_file)
+        expected = datetime.strptime("21/10/2020 03:00:00", '%d/%m/%Y %H:%M:%S')
+        actual = create_pdm_trigger.generate_cut_off_date(export_date_file)
 
-    assert actual == expected
+        assert actual == expected
 
 
-def test_generate_cut_off_date_when_no_file():
-    export_date_file = "/tmp/test.txt"
-    if os.path.isfile(export_date_file):
-        os.remove(export_date_file)
+    def test_generate_cut_off_date_when_no_file():
+        export_date_file = "/tmp/test.txt"
+        if os.path.isfile(export_date_file):
+            os.remove(export_date_file)
 
-    expected = None
-    actual = create_pdm_trigger.generate_cut_off_date(export_date_file)
+        expected = None
+        actual = create_pdm_trigger.generate_cut_off_date(export_date_file)
 
-    assert actual == expected
+        assert actual == expected
 
 
-def test_generate_cut_off_date_when_empty_file():
-    export_date_file = "/tmp/test.txt"
-    if os.path.isfile(export_date_file):
-        os.remove(export_date_file)
+    def test_generate_cut_off_date_when_empty_file():
+        export_date_file = "/tmp/test.txt"
+        if os.path.isfile(export_date_file):
+            os.remove(export_date_file)
 
-    with open(export_date_file, "wt") as f:
-        export_date = f.write("")
+        with open(export_date_file, "wt") as f:
+            export_date = f.write("")
 
-    expected = None
-    actual = create_pdm_trigger.generate_cut_off_date(export_date_file)
+        expected = None
+        actual = create_pdm_trigger.generate_cut_off_date(export_date_file)
 
-    assert actual == expected
+        assert actual == expected
 
 
-def test_put_cloudwatch_event_rule():
-    now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
-    cron = "1 1 1 1 1 1 1"
-    
-    events_client = mock.MagicMock()
-    events_client.put_rule = mock.MagicMock()
+    def test_put_cloudwatch_event_rule():
+        now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
+        cron = "1 1 1 1 1 1 1"
+        
+        events_client = mock.MagicMock()
+        events_client.put_rule = mock.MagicMock()
 
-    expected = "pdm_cw_emr_launcher_schedule_18_09_2019_23_57_19"
-    actual = create_pdm_trigger.put_cloudwatch_event_rule(
-        events_client, now, cron
-    )
+        expected = "pdm_cw_emr_launcher_schedule_18_09_2019_23_57_19"
+        actual = create_pdm_trigger.put_cloudwatch_event_rule(
+            events_client, now, cron
+        )
 
-    events_client.put_rule.assert_called_once_with(
-        Name=expected,
-        ScheduleExpression=cron,
-        State="ENABLED",
-        Description='Triggers PDM EMR Launcher',
-    )
+        events_client.put_rule.assert_called_once_with(
+            Name=expected,
+            ScheduleExpression=cron,
+            State="ENABLED",
+            Description='Triggers PDM EMR Launcher',
+        )
 
-    assert actual == expected
+        assert actual == expected
 
 
-def test_put_cloudwatch_event_target():
-    now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
-    id_string = "pdm_cw_emr_launcher_target_18_09_2019_23_57_19"
-    rule_name = "pdm_cw_emr_launcher_schedule_18_09_2019_23_57_19"
+    def test_put_cloudwatch_event_target():
+        now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
+        id_string = "pdm_cw_emr_launcher_target_18_09_2019_23_57_19"
+        rule_name = "pdm_cw_emr_launcher_schedule_18_09_2019_23_57_19"
 
-    events_client = mock.MagicMock()
-    events_client.put_targets = mock.MagicMock()
+        events_client = mock.MagicMock()
+        events_client.put_targets = mock.MagicMock()
 
-    actual = create_pdm_trigger.put_cloudwatch_event_target(
-        events_client, now, rule_name
-    )
+        actual = create_pdm_trigger.put_cloudwatch_event_target(
+            events_client, now, rule_name
+        )
 
-    events_client.put_targets.assert_called_once_with(
-        Rule=rule_name,
-        Targets=[
-            {
-                'Id': id_string,
-                'Arn': "${pdm_lambda_trigger_arn}",
-            },
-        ]
-    )
+        events_client.put_targets.assert_called_once_with(
+            Rule=rule_name,
+            Targets=[
+                {
+                    'Id': id_string,
+                    'Arn': "${pdm_lambda_trigger_arn}",
+                },
+            ]
+        )
 
 
-def test_should_skip_returns_true_when_after_cut_off(monkeypatch):
-    now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
-    do_not_trigger_after = datetime.strptime("18/09/19 22:55:19", '%d/%m/%y %H:%M:%S')
+    @mock.patch("steps.create_pdm_trigger.check_should_skip_step")
+    def test_should_skip_returns_true_when_after_cut_off(
+        self,
+        check_should_skip_step_mock,
+    ):
+        now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
+        do_not_trigger_after = datetime.strptime("18/09/19 22:55:19", '%d/%m/%y %H:%M:%S')
 
-    monkeypatch.setattr(
-        steps.create_pdm_trigger, "check_should_skip_step", return_false
-    )
+        check_should_skip_step_mock = mock.MagicMock()
+        check_should_skip_step_mock.return_value = False
 
-    actual = create_pdm_trigger.should_step_be_skipped(
-        "false",
-        now, 
-        do_not_trigger_after
-    )
+        actual = create_pdm_trigger.should_step_be_skipped(
+            "false",
+            now, 
+            do_not_trigger_after
+        )
 
-    assert True == actual
+        assert True == actual
 
 
-def test_should_skip_returns_true_when_after_cut_off_but_resume_step_returns_true(monkeypatch):
-    now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
-    do_not_trigger_after = datetime.strptime("18/09/19 23:59:19", '%d/%m/%y %H:%M:%S')
+    @mock.patch("steps.create_pdm_trigger.check_should_skip_step")
+    def test_should_skip_returns_true_when_after_cut_off_but_resume_step_returns_true(
+        self,
+        check_should_skip_step_mock,
+    ):
+        now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
+        do_not_trigger_after = datetime.strptime("18/09/19 23:59:19", '%d/%m/%y %H:%M:%S')
 
-    monkeypatch.setattr(
-        steps.create_pdm_trigger, "check_should_skip_step", return_true
-    )
+        check_should_skip_step_mock = mock.MagicMock()
+        check_should_skip_step_mock.return_value = True
 
-    actual = create_pdm_trigger.should_step_be_skipped(
-        "false",
-        now, 
-        do_not_trigger_after
-    )
+        actual = create_pdm_trigger.should_step_be_skipped(
+            "false",
+            now, 
+            do_not_trigger_after
+        )
 
-    assert True == actual
+        assert True == actual
 
 
-def test_should_skip_returns_false_when_before_cut_off_and_resume_step_returns_false(monkeypatch):
-    now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
-    do_not_trigger_after = datetime.strptime("18/09/19 23:59:19", '%d/%m/%y %H:%M:%S')
+    @mock.patch("steps.create_pdm_trigger.check_should_skip_step")
+    def test_should_skip_returns_false_when_before_cut_off_and_resume_step_returns_false(
+        self,
+        check_should_skip_step_mock,
+    ):
+        now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
+        do_not_trigger_after = datetime.strptime("18/09/19 23:59:19", '%d/%m/%y %H:%M:%S')
 
-    monkeypatch.setattr(
-        steps.create_pdm_trigger, "check_should_skip_step", return_false
-    )
+        check_should_skip_step_mock = mock.MagicMock()
+        check_should_skip_step_mock.return_value = False
 
-    actual = create_pdm_trigger.should_step_be_skipped(
-        "false",
-        now, 
-        do_not_trigger_after
-    )
+        actual = create_pdm_trigger.should_step_be_skipped(
+            "false",
+            now, 
+            do_not_trigger_after
+        )
 
-    assert False == actual
+        assert False == actual
 
 
-def test_should_skip_returns_true_when_skip_setting_set_to_true(monkeypatch):
-    now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
-    do_not_trigger_after = datetime.strptime("18/09/19 23:59:19", '%d/%m/%y %H:%M:%S')
+    @mock.patch("steps.create_pdm_trigger.check_should_skip_step")
+    def test_should_skip_returns_true_when_skip_setting_set_to_true(
+        self,
+        check_should_skip_step_mock,
+    ):
+        now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
+        do_not_trigger_after = datetime.strptime("18/09/19 23:59:19", '%d/%m/%y %H:%M:%S')
 
-    monkeypatch.setattr(
-        steps.create_pdm_trigger, "check_should_skip_step", return_false
-    )
+        check_should_skip_step_mock = mock.MagicMock()
+        check_should_skip_step_mock.return_value = False
 
-    actual = create_pdm_trigger.should_step_be_skipped(
-        "true",
-        now, 
-        do_not_trigger_after
-    )
+        actual = create_pdm_trigger.should_step_be_skipped(
+            "true",
+            now, 
+            do_not_trigger_after
+        )
 
-    assert True == actual
+        assert True == actual
 
 
-def test_should_skip_returns_true_when_skip_setting_set_to_true_upper_case(monkeypatch):
-    now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
-    do_not_trigger_after = datetime.strptime("18/09/19 23:59:19", '%d/%m/%y %H:%M:%S')
+    @mock.patch("steps.create_pdm_trigger.check_should_skip_step")
+    def test_should_skip_returns_true_when_skip_setting_set_to_true_upper_case(
+        self,
+        check_should_skip_step_mock,
+    ):
+        now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
+        do_not_trigger_after = datetime.strptime("18/09/19 23:59:19", '%d/%m/%y %H:%M:%S')
 
-    monkeypatch.setattr(
-        steps.create_pdm_trigger, "check_should_skip_step", return_false
-    )
+        check_should_skip_step_mock = mock.MagicMock()
+        check_should_skip_step_mock.return_value = False
 
-    actual = create_pdm_trigger.should_step_be_skipped(
-        "TRUE",
-        now, 
-        do_not_trigger_after
-    )
+        actual = create_pdm_trigger.should_step_be_skipped(
+            "TRUE",
+            now, 
+            do_not_trigger_after
+        )
 
-    assert True == actual
+        assert True == actual
 
 
-def test_get_cron_gives_cut_out_time_when_before_cut_off():
-    now = datetime.strptime("18/09/19 01:55:19", '%d/%m/%y %H:%M:%S')
-    do_not_run_before = datetime.strptime("18/09/19 02:55:19", '%d/%m/%y %H:%M:%S')
+    def test_get_cron_gives_cut_out_time_when_before_cut_off():
+        now = datetime.strptime("18/09/19 01:55:19", '%d/%m/%y %H:%M:%S')
+        do_not_run_before = datetime.strptime("18/09/19 02:55:19", '%d/%m/%y %H:%M:%S')
 
-    expected = "55 02 18 09 ? 2019"
-    actual = create_pdm_trigger.get_cron(
-        now, 
-        do_not_run_before
-    )
+        expected = "55 02 18 09 ? 2019"
+        actual = create_pdm_trigger.get_cron(
+            now, 
+            do_not_run_before
+        )
 
-    assert expected == actual
+        assert expected == actual
 
 
-def test_get_cron_gives_now_plus_5_minutes_when_after_cut_off():
-    now = datetime.strptime("18/09/19 01:57:19", '%d/%m/%y %H:%M:%S')
-    do_not_run_before = datetime.strptime("18/09/19 00:55:19", '%d/%m/%y %H:%M:%S')
+    def test_get_cron_gives_now_plus_5_minutes_when_after_cut_off():
+        now = datetime.strptime("18/09/19 01:57:19", '%d/%m/%y %H:%M:%S')
+        do_not_run_before = datetime.strptime("18/09/19 00:55:19", '%d/%m/%y %H:%M:%S')
 
-    expected = "02 02 18 09 ? 2019"
-    actual = create_pdm_trigger.get_cron(
-        now, 
-        do_not_run_before
-    )
+        expected = "02 02 18 09 ? 2019"
+        actual = create_pdm_trigger.get_cron(
+            now, 
+            do_not_run_before
+        )
 
-    assert expected == actual
+        assert expected == actual
 
 
-def test_get_cron_gives_cut_out_time_when_before_cut_off_over_date_boundary():
-    now = datetime.strptime("18/09/19 23:55:19", '%d/%m/%y %H:%M:%S')
-    do_not_run_before = datetime.strptime("19/09/19 01:55:19", '%d/%m/%y %H:%M:%S')
+    def test_get_cron_gives_cut_out_time_when_before_cut_off_over_date_boundary():
+        now = datetime.strptime("18/09/19 23:55:19", '%d/%m/%y %H:%M:%S')
+        do_not_run_before = datetime.strptime("19/09/19 01:55:19", '%d/%m/%y %H:%M:%S')
 
-    expected = "55 01 19 09 ? 2019"
-    actual = create_pdm_trigger.get_cron(
-        now, 
-        do_not_run_before
-    )
+        expected = "55 01 19 09 ? 2019"
+        actual = create_pdm_trigger.get_cron(
+            now, 
+            do_not_run_before
+        )
 
-    assert expected == actual
+        assert expected == actual
 
 
-def test_get_cron_gives_now_plus_5_minutes_when_after_cut_off_over_date_boundary():
-    now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
-    do_not_run_before = datetime.strptime("18/09/19 22:55:19", '%d/%m/%y %H:%M:%S')
+    def test_get_cron_gives_now_plus_5_minutes_when_after_cut_off_over_date_boundary():
+        now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
+        do_not_run_before = datetime.strptime("18/09/19 22:55:19", '%d/%m/%y %H:%M:%S')
 
-    expected = "02 00 19 09 ? 2019"
-    actual = create_pdm_trigger.get_cron(
-        now, 
-        do_not_run_before
-    )
+        expected = "02 00 19 09 ? 2019"
+        actual = create_pdm_trigger.get_cron(
+            now, 
+            do_not_run_before
+        )
 
-    assert expected == actual
-
-
-def return_true():
-    return True
-
-
-def return_false():
-    return False
-
-
-def cut_off_date():
-    return datetime.strptime("18/09/19 22:55:19", '%d/%m/%y %H:%M:%S')
+        assert expected == actual

--- a/tests/test_trigger_pdm.py
+++ b/tests/test_trigger_pdm.py
@@ -89,7 +89,7 @@ def test_generate_do_not_run_before_date():
     with open(export_date_file, "wt") as f:
         export_date = f.write(export_date)
 
-    expected = datetime.strptime("20/10/2020 15:00:00", '%d/%m/%y %H:%M:%S')
+    expected = datetime.strptime("20/10/2020 15:00:00", '%d/%m/%Y %H:%M:%S')
     actual = create_pdm_trigger.generate_do_not_run_before_date(export_date_file)
 
     assert actual == expected
@@ -129,7 +129,7 @@ def test_generate_cut_off_date():
     with open(export_date_file, "wt") as f:
         export_date = f.write(export_date)
 
-    expected = datetime.strptime("21/10/2020 03:00:00", '%d/%m/%y %H:%M:%S')
+    expected = datetime.strptime("21/10/2020 03:00:00", '%d/%m/%Y %H:%M:%S')
     actual = create_pdm_trigger.generate_cut_off_date(export_date_file)
 
     assert actual == expected

--- a/tests/test_trigger_pdm.py
+++ b/tests/test_trigger_pdm.py
@@ -1,7 +1,6 @@
 import boto3
 import unittest
 import os
-import steps
 import pytest
 
 from steps import create_pdm_trigger
@@ -17,7 +16,7 @@ class TestReplayer(unittest.TestCase):
     @mock.patch("steps.create_pdm_trigger.get_events_client")
     @mock.patch("steps.create_pdm_trigger.should_step_be_skipped")
     @mock.patch("steps.create_pdm_trigger.generate_cut_off_date")
-    @mock.patch("create_pdm_trigger.get_now")
+    @mock.patch("steps.create_pdm_trigger.get_now")
     def test_create_pdm_trigger(
         self,
         get_now_mock,

--- a/tests/test_trigger_pdm.py
+++ b/tests/test_trigger_pdm.py
@@ -34,16 +34,6 @@ class TestReplayer(unittest.TestCase):
         cron = "test cron"
         rule_name = "test rule"
 
-        events_client = mock.MagicMock()
-        get_now_mock = mock.MagicMock()
-        generate_cut_off_date_mock = mock.MagicMock()
-        should_step_be_skipped_mock = mock.MagicMock()
-        get_events_client_mock = mock.MagicMock()
-        generate_do_not_run_before_date_mock = mock.MagicMock()
-        get_cron_mock = mock.MagicMock()
-        put_cloudwatch_event_rule_mock = mock.MagicMock()
-        put_cloudwatch_event_target_mock = mock.MagicMock()
-
         get_now_mock.return_value = now
         generate_cut_off_date_mock.return_value = do_not_run_after
         should_step_be_skipped_mock.return_value = False
@@ -53,7 +43,7 @@ class TestReplayer(unittest.TestCase):
         put_cloudwatch_event_rule_mock.return_value = rule_name
         
         response = create_pdm_trigger.create_pdm_trigger(
-            False, 
+            "false", 
         )
         
         get_now_mock.assert_called_once()
@@ -79,6 +69,50 @@ class TestReplayer(unittest.TestCase):
             now,
             rule_name,
         )
+
+
+    @mock.patch("steps.create_pdm_trigger.put_cloudwatch_event_target")
+    @mock.patch("steps.create_pdm_trigger.put_cloudwatch_event_rule")
+    @mock.patch("steps.create_pdm_trigger.get_cron")
+    @mock.patch("steps.create_pdm_trigger.generate_do_not_run_before_date")
+    @mock.patch("steps.create_pdm_trigger.get_events_client")
+    @mock.patch("steps.create_pdm_trigger.should_step_be_skipped")
+    @mock.patch("steps.create_pdm_trigger.generate_cut_off_date")
+    @mock.patch("steps.create_pdm_trigger.get_now")
+    def test_create_pdm_trigger_skip_step(
+        self,
+        get_now_mock,
+        generate_cut_off_date_mock,
+        should_step_be_skipped_mock,
+        get_events_client_mock,
+        generate_do_not_run_before_date_mock,
+        get_cron_mock,
+        put_cloudwatch_event_rule_mock,
+        put_cloudwatch_event_target_mock,
+    ):
+        now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
+        do_not_run_after = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
+
+        get_now_mock.return_value = now
+        generate_cut_off_date_mock.return_value = do_not_run_after
+        should_step_be_skipped_mock.return_value = True
+        
+        response = create_pdm_trigger.create_pdm_trigger(
+            "true", 
+        )
+        
+        get_now_mock.assert_called_once()
+        generate_cut_off_date_mock.assert_called_once()
+        should_step_be_skipped_mock.assert_called_once_with(
+            "true",
+            now,
+            do_not_run_after,
+        )
+        get_events_client_mock.assert_not_called()
+        generate_do_not_run_before_date_mock.assert_not_called()
+        get_cron_mock.assert_not_called()
+        put_cloudwatch_event_rule_mock.assert_not_called()
+        put_cloudwatch_event_target_mock.assert_not_called()
 
 
     def test_generate_do_not_run_before_date(self):
@@ -214,7 +248,6 @@ class TestReplayer(unittest.TestCase):
         now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
         do_not_trigger_after = datetime.strptime("18/09/19 22:55:19", '%d/%m/%y %H:%M:%S')
 
-        check_should_skip_step_mock = mock.MagicMock()
         check_should_skip_step_mock.return_value = False
 
         actual = create_pdm_trigger.should_step_be_skipped(
@@ -234,7 +267,6 @@ class TestReplayer(unittest.TestCase):
         now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
         do_not_trigger_after = datetime.strptime("18/09/19 23:59:19", '%d/%m/%y %H:%M:%S')
 
-        check_should_skip_step_mock = mock.MagicMock()
         check_should_skip_step_mock.return_value = True
 
         actual = create_pdm_trigger.should_step_be_skipped(
@@ -254,7 +286,6 @@ class TestReplayer(unittest.TestCase):
         now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
         do_not_trigger_after = datetime.strptime("18/09/19 23:59:19", '%d/%m/%y %H:%M:%S')
 
-        check_should_skip_step_mock = mock.MagicMock()
         check_should_skip_step_mock.return_value = False
 
         actual = create_pdm_trigger.should_step_be_skipped(
@@ -274,7 +305,6 @@ class TestReplayer(unittest.TestCase):
         now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
         do_not_trigger_after = datetime.strptime("18/09/19 23:59:19", '%d/%m/%y %H:%M:%S')
 
-        check_should_skip_step_mock = mock.MagicMock()
         check_should_skip_step_mock.return_value = False
 
         actual = create_pdm_trigger.should_step_be_skipped(
@@ -294,7 +324,6 @@ class TestReplayer(unittest.TestCase):
         now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
         do_not_trigger_after = datetime.strptime("18/09/19 23:59:19", '%d/%m/%y %H:%M:%S')
 
-        check_should_skip_step_mock = mock.MagicMock()
         check_should_skip_step_mock.return_value = False
 
         actual = create_pdm_trigger.should_step_be_skipped(

--- a/tests/test_trigger_pdm.py
+++ b/tests/test_trigger_pdm.py
@@ -1,9 +1,11 @@
 import boto3
 import unittest
 import os
+import steps
 
 from steps import create_pdm_trigger
 from datetime import datetime
+from unittest import mock
 
 
 # @mock_events
@@ -38,7 +40,7 @@ def test_put_cloudwatch_event_rule():
     events_client = mock.MagicMock()
     events_client.put_rule = mock.MagicMock()
 
-    expected = "pdm_cw_emr_launcher_schedule_18_09_19_23_57_19"
+    expected = "pdm_cw_emr_launcher_schedule_18_09_2019_23_57_19"
     actual = create_pdm_trigger.put_cloudwatch_event_rule(
         events_client, now, cron
     )
@@ -55,8 +57,8 @@ def test_put_cloudwatch_event_rule():
 
 def test_put_cloudwatch_event_target():
     now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
-    id_string = "pdm_cw_emr_launcher_target_18_09_19_23_57_19"
-    rule_name = "pdm_cw_emr_launcher_schedule_18_09_19_23_57_19"
+    id_string = "pdm_cw_emr_launcher_target_18_09_2019_23_57_19"
+    rule_name = "pdm_cw_emr_launcher_schedule_18_09_2019_23_57_19"
 
     events_client = mock.MagicMock()
     events_client.put_targets = mock.MagicMock()
@@ -128,7 +130,7 @@ def test_get_cron_gives_cut_out_time_when_before_cut_off():
     now = datetime.strptime("18/09/19 01:55:19", '%d/%m/%y %H:%M:%S')
     do_not_run_before = datetime.strptime("18/09/19 02:55:19", '%d/%m/%y %H:%M:%S')
 
-    expected = "19 55 02 18 09 ? 19"
+    expected = "19 55 02 18 09 ? 2019"
     actual = create_pdm_trigger.get_cron(
         now, 
         do_not_run_before
@@ -141,7 +143,7 @@ def test_get_cron_gives_now_plus_5_minutes_when_after_cut_off():
     now = datetime.strptime("18/09/19 01:57:19", '%d/%m/%y %H:%M:%S')
     do_not_run_before = datetime.strptime("18/09/19 00:55:19", '%d/%m/%y %H:%M:%S')
 
-    expected = "19 02 02 18 09 ? 19"
+    expected = "19 02 02 18 09 ? 2019"
     actual = create_pdm_trigger.get_cron(
         now, 
         do_not_run_before
@@ -154,7 +156,7 @@ def test_get_cron_gives_cut_out_time_when_before_cut_off_over_date_boundary():
     now = datetime.strptime("18/09/19 23:55:19", '%d/%m/%y %H:%M:%S')
     do_not_run_before = datetime.strptime("19/09/19 01:55:19", '%d/%m/%y %H:%M:%S')
 
-    expected = "19 55 01 19 09 ? 19"
+    expected = "19 55 01 19 09 ? 2019"
     actual = create_pdm_trigger.get_cron(
         now, 
         do_not_run_before
@@ -167,7 +169,7 @@ def test_get_cron_gives_now_plus_5_minutes_when_after_cut_off_over_date_boundary
     now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
     do_not_run_before = datetime.strptime("18/09/19 22:55:19", '%d/%m/%y %H:%M:%S')
 
-    expected = "19 02 00 19 09 ? 19"
+    expected = "19 02 00 19 09 ? 2019"
     actual = create_pdm_trigger.get_cron(
         now, 
         do_not_run_before

--- a/tests/test_trigger_pdm.py
+++ b/tests/test_trigger_pdm.py
@@ -8,7 +8,8 @@ from datetime import datetime
 from unittest import mock
 
 TMP_TEST_FILE = "/tmp/test.txt"
-EXPORT_DATE = "18-09-19"
+EXPORT_DATE = "2019-09-18"
+EXPORT_DATE_FILE_NAME = "/opt/emr/export_date.txt"
 
 
 class TestReplayer(unittest.TestCase):
@@ -56,6 +57,9 @@ class TestReplayer(unittest.TestCase):
         )
         
         get_now_mock.assert_called_once()
+        get_export_date_mock.assert_called_once_with(
+            EXPORT_DATE_FILE_NAME,
+        )
         generate_cut_off_date_mock.assert_called_once_with(
             EXPORT_DATE,
         )
@@ -92,7 +96,7 @@ class TestReplayer(unittest.TestCase):
     @mock.patch("steps.create_pdm_trigger.get_events_client")
     @mock.patch("steps.create_pdm_trigger.should_step_be_skipped")
     @mock.patch("steps.create_pdm_trigger.generate_cut_off_date")
-    @mock.patch("steps.create_pdm_trigger.generate_cut_off_date")
+    @mock.patch("steps.create_pdm_trigger.get_export_date")
     @mock.patch("steps.create_pdm_trigger.get_now")
     def test_create_pdm_trigger_skip_step(
         self,
@@ -119,6 +123,9 @@ class TestReplayer(unittest.TestCase):
         )
 
         get_now_mock.assert_called_once()
+        get_export_date_mock.assert_called_once_with(
+            EXPORT_DATE_FILE_NAME,
+        )
         generate_cut_off_date_mock.assert_called_once_with(
             EXPORT_DATE,
         )
@@ -135,7 +142,7 @@ class TestReplayer(unittest.TestCase):
 
 
     def test_generate_do_not_run_before_date(self):
-        expected = "18/09/2019 15:00:00"
+        expected = datetime.strptime("2019-09-18 15:00:00", '%Y-%m-%d %H:%M:%S')
         actual = create_pdm_trigger.generate_do_not_run_before_date(EXPORT_DATE)
 
         assert actual == expected
@@ -181,8 +188,8 @@ class TestReplayer(unittest.TestCase):
 
 
     def test_generate_cut_off_date(self):
-        expected = "19/09/2019 03:00:00"
-        actual = create_pdm_trigger.generate_cut_off_date(export_date_file)
+        expected = datetime.strptime("2019-09-19 03:00:00", '%Y-%m-%d %H:%M:%S')
+        actual = create_pdm_trigger.generate_cut_off_date(EXPORT_DATE)
 
         assert actual == expected
 

--- a/tests/test_trigger_pdm.py
+++ b/tests/test_trigger_pdm.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from unittest import mock
 
 TMP_TEST_FILE = "/tmp/test.txt"
-EXPORT_DATE = "18/09/19"
+EXPORT_DATE = "18-09-19"
 
 
 class TestReplayer(unittest.TestCase):

--- a/tests/test_trigger_pdm.py
+++ b/tests/test_trigger_pdm.py
@@ -247,26 +247,6 @@ class TestReplayer(unittest.TestCase):
 
 
     @mock.patch("steps.create_pdm_trigger.check_should_skip_step")
-    def test_should_skip_returns_false_when_before_cut_off_and_resume_step_returns_false(
-        self,
-        check_should_skip_step_mock,
-    ):
-        now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
-        do_not_trigger_after = datetime.strptime("18/09/19 23:59:19", '%d/%m/%y %H:%M:%S')
-
-        check_should_skip_step_mock = mock.MagicMock()
-        check_should_skip_step_mock.return_value = False
-
-        actual = create_pdm_trigger.should_step_be_skipped(
-            "false",
-            now, 
-            do_not_trigger_after
-        )
-
-        assert False == actual
-
-
-    @mock.patch("steps.create_pdm_trigger.check_should_skip_step")
     def test_should_skip_returns_true_when_skip_setting_set_to_true(
         self,
         check_should_skip_step_mock,
@@ -304,6 +284,26 @@ class TestReplayer(unittest.TestCase):
         )
 
         assert True == actual
+
+
+    @mock.patch("steps.create_pdm_trigger.check_should_skip_step")
+    def test_should_skip_returns_false_when_before_cut_off_and_resume_step_returns_false(
+        self,
+        check_should_skip_step_mock,
+    ):
+        now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
+        do_not_trigger_after = datetime.strptime("18/09/19 23:59:19", '%d/%m/%y %H:%M:%S')
+
+        check_should_skip_step_mock = mock.MagicMock()
+        check_should_skip_step_mock.return_value = False
+
+        actual = create_pdm_trigger.should_step_be_skipped(
+            "false",
+            now, 
+            do_not_trigger_after
+        )
+
+        assert False == actual
 
 
     def test_get_cron_gives_cut_out_time_when_before_cut_off(self):
@@ -356,3 +356,7 @@ class TestReplayer(unittest.TestCase):
         )
 
         assert expected == actual
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_trigger_pdm.py
+++ b/tests/test_trigger_pdm.py
@@ -53,7 +53,7 @@ class TestReplayer(unittest.TestCase):
         get_cron_mock.return_value = cron
         put_cloudwatch_event_rule_mock.return_value = rule_name
         
-        response = send_notification.create_pdm_trigger(
+        response = create_pdm_trigger.create_pdm_trigger(
             False, 
         )
         
@@ -97,7 +97,7 @@ class TestReplayer(unittest.TestCase):
         assert actual == expected
 
 
-    def test_generate_do_not_run_before_date_when_no_file():
+    def test_generate_do_not_run_before_date_when_no_file(self):
         export_date_file = "/tmp/test.txt"
         if os.path.isfile(export_date_file):
             os.remove(export_date_file)
@@ -108,7 +108,7 @@ class TestReplayer(unittest.TestCase):
         assert actual == expected
 
 
-    def test_generate_do_not_run_before_date_when_empty_file():
+    def test_generate_do_not_run_before_date_when_empty_file(self):
         export_date_file = "/tmp/test.txt"
         if os.path.isfile(export_date_file):
             os.remove(export_date_file)
@@ -122,7 +122,7 @@ class TestReplayer(unittest.TestCase):
         assert actual == expected
 
 
-    def test_generate_cut_off_date():
+    def test_generate_cut_off_date(self):
         export_date = "2020-10-20"
         export_date_file = "/tmp/test.txt"
         if os.path.isfile(export_date_file):
@@ -137,7 +137,7 @@ class TestReplayer(unittest.TestCase):
         assert actual == expected
 
 
-    def test_generate_cut_off_date_when_no_file():
+    def test_generate_cut_off_date_when_no_file(self):
         export_date_file = "/tmp/test.txt"
         if os.path.isfile(export_date_file):
             os.remove(export_date_file)
@@ -148,7 +148,7 @@ class TestReplayer(unittest.TestCase):
         assert actual == expected
 
 
-    def test_generate_cut_off_date_when_empty_file():
+    def test_generate_cut_off_date_when_empty_file(self):
         export_date_file = "/tmp/test.txt"
         if os.path.isfile(export_date_file):
             os.remove(export_date_file)
@@ -162,7 +162,7 @@ class TestReplayer(unittest.TestCase):
         assert actual == expected
 
 
-    def test_put_cloudwatch_event_rule():
+    def test_put_cloudwatch_event_rule(self):
         now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
         cron = "1 1 1 1 1 1 1"
         
@@ -184,7 +184,7 @@ class TestReplayer(unittest.TestCase):
         assert actual == expected
 
 
-    def test_put_cloudwatch_event_target():
+    def test_put_cloudwatch_event_target(self):
         now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
         id_string = "pdm_cw_emr_launcher_target_18_09_2019_23_57_19"
         rule_name = "pdm_cw_emr_launcher_schedule_18_09_2019_23_57_19"
@@ -307,7 +307,7 @@ class TestReplayer(unittest.TestCase):
         assert True == actual
 
 
-    def test_get_cron_gives_cut_out_time_when_before_cut_off():
+    def test_get_cron_gives_cut_out_time_when_before_cut_off(self):
         now = datetime.strptime("18/09/19 01:55:19", '%d/%m/%y %H:%M:%S')
         do_not_run_before = datetime.strptime("18/09/19 02:55:19", '%d/%m/%y %H:%M:%S')
 
@@ -320,7 +320,7 @@ class TestReplayer(unittest.TestCase):
         assert expected == actual
 
 
-    def test_get_cron_gives_now_plus_5_minutes_when_after_cut_off():
+    def test_get_cron_gives_now_plus_5_minutes_when_after_cut_off(self):
         now = datetime.strptime("18/09/19 01:57:19", '%d/%m/%y %H:%M:%S')
         do_not_run_before = datetime.strptime("18/09/19 00:55:19", '%d/%m/%y %H:%M:%S')
 
@@ -333,7 +333,7 @@ class TestReplayer(unittest.TestCase):
         assert expected == actual
 
 
-    def test_get_cron_gives_cut_out_time_when_before_cut_off_over_date_boundary():
+    def test_get_cron_gives_cut_out_time_when_before_cut_off_over_date_boundary(self):
         now = datetime.strptime("18/09/19 23:55:19", '%d/%m/%y %H:%M:%S')
         do_not_run_before = datetime.strptime("19/09/19 01:55:19", '%d/%m/%y %H:%M:%S')
 
@@ -346,7 +346,7 @@ class TestReplayer(unittest.TestCase):
         assert expected == actual
 
 
-    def test_get_cron_gives_now_plus_5_minutes_when_after_cut_off_over_date_boundary():
+    def test_get_cron_gives_now_plus_5_minutes_when_after_cut_off_over_date_boundary(self):
         now = datetime.strptime("18/09/19 23:57:19", '%d/%m/%y %H:%M:%S')
         do_not_run_before = datetime.strptime("18/09/19 22:55:19", '%d/%m/%y %H:%M:%S')
 


### PR DESCRIPTION
Generate the cloudwatch rule and target to trigger PDM via an ADG step, not hardcoded in TF. To do this, need to use the export date which is now passed through to ADG so need to work out the cut offs incase retries for ADG go past the midnight boundary.

Do not trigger PDM if:

1. Setting passed in to skip (for lower envs)
2. Time is past 3am on the day AFTER the export date (i.e. running in to the next day's runs)

If time is before 3pm on day of export, then generate a cloudwatch rule to trigger PDM at 3pm that day.
If time is after 3pm on day of export, then generate a cloudwatch rule to trigger PDM 5 minutes from now.

The dynamo db table's date field switched to have the export date, not the date of run as this is what matters. Also pass this through to PDM so it can use it too.

This means ADG and PDM are now aware of the day the data they are dealing with was actually exported.