### PR TITLE
Use UTC for the date checks when comparing with current time because …

### DIFF
--- a/local.tf
+++ b/local.tf
@@ -412,6 +412,6 @@ locals {
     qa          = "01"
     integration = "01"
     preprod     = "01"
-    production  = "14" # 2pm (UTC) the day of the export as before would interfere with the working day's queries from users
+    production  = "14" # 1400 (UTC) the day of the export as before would interfere with the working day's queries from users
   }
 }

--- a/local.tf
+++ b/local.tf
@@ -408,7 +408,7 @@ locals {
   }
 
   pdm_start_do_not_run_before_hour = {
-    development = "01" # 1am (UTC) the day of the export as for lower environments we want to run on demand
+    development = "01" # 0100 (UTC) the day of the export as for lower environments we want to run on demand
     qa          = "01"
     integration = "01"
     preprod     = "01"

--- a/local.tf
+++ b/local.tf
@@ -400,18 +400,18 @@ locals {
   emr_subnet_non_capacity_reserved_environments = "eu-west-2b"
 
   pdm_start_do_not_run_after_hour = {
-    development = "23" # 11pm the day after the export as for lower environments we want to run on demand
+    development = "23" # 11pm (UTC) the day after the export as for lower environments we want to run on demand
     qa          = "23"
     integration = "23"
     preprod     = "23"
-    production  = "01" # 1am the day after the export as would then interfere with next day's jobs
+    production  = "02" # 1am (UTC) the day after the export as would then interfere with next day's jobs
   }
 
   pdm_start_do_not_run_before_hour = {
-    development = "01" # 1am the day of the export as for lower environments we want to run on demand
+    development = "01" # 1am (UTC) the day of the export as for lower environments we want to run on demand
     qa          = "01"
     integration = "01"
     preprod     = "01"
-    production  = "13" # 1pm the day of the export as before would interfere with the working day's queries from users
+    production  = "14" # 2pm (UTC) the day of the export as before would interfere with the working day's queries from users
   }
 }

--- a/local.tf
+++ b/local.tf
@@ -404,7 +404,7 @@ locals {
     qa          = "23"
     integration = "23"
     preprod     = "23"
-    production  = "02" # 1am (UTC) the day after the export as would then interfere with next day's jobs
+    production  = "02" # 0200 (UTC) the day after the export as would then interfere with next day's jobs
   }
 
   pdm_start_do_not_run_before_hour = {

--- a/local.tf
+++ b/local.tf
@@ -400,7 +400,7 @@ locals {
   emr_subnet_non_capacity_reserved_environments = "eu-west-2b"
 
   pdm_start_do_not_run_after_hour = {
-    development = "23" # 11pm (UTC) the day after the export as for lower environments we want to run on demand
+    development = "23" # 2300 (UTC) the day after the export as for lower environments we want to run on demand
     qa          = "23"
     integration = "23"
     preprod     = "23"

--- a/steps/create_pdm_trigger.py
+++ b/steps/create_pdm_trigger.py
@@ -97,7 +97,7 @@ def validate_required_args(args):
 
 
 def get_now():
-    return datetime.now()
+    return datetime.utcnow()
 
 
 def generate_cut_off_date(export_date, do_not_run_after_hour):


### PR DESCRIPTION
Use UTC for the date checks when comparing with current time because cron is utc so the trigger itself is in UTC