### PR TITLE
make last step to look for sns notification. That way e2e pipeline wi…

### DIFF
--- a/bootstrap_actions/update_dynamo.sh
+++ b/bootstrap_actions/update_dynamo.sh
@@ -31,7 +31,7 @@
   IN_PROGRESS_STATUS="IN_PROGRESS"
   CANCELLED_STATUS="CANCELLED"
 
-  FINAL_STEP_NAME="flush-pushgateway"
+  FINAL_STEP_NAME="sns-notification"
 
   while [[ ! -f "$CORRELATION_ID_FILE" ]] && [[ ! -f "$S3_PREFIX_FILE" ]] && [[ ! -f "$SNAPSHOT_TYPE_FILE" ]] && [[ ! -f "$EXPORT_DATE_FILE" ]]
   do


### PR DESCRIPTION
…ll not fail and even if flush pushgateway fails the pipeline run should not be marked as failed

Signed-off-by: Levan Kirvalidze <levanik@live.com>