### PR TITLE
mark ADG as complete when spark-submit is successful

### DIFF
--- a/bootstrap_actions.tf
+++ b/bootstrap_actions.tf
@@ -81,7 +81,7 @@ resource "aws_s3_bucket_object" "status_metrics_sh" {
   content = templatefile("${path.module}/bootstrap_actions/status_metrics.sh",
     {
       adg_pushgateway_hostname = data.terraform_remote_state.metrics_infrastructure.outputs.adg_pushgateway_hostname
-      final_step               = local.dynamodb_final_step[local.environment]
+      final_step               = "spark-submit" # Stops skipping final step on retry, we should mark success at data cretation.
 
     }
   )


### PR DESCRIPTION
Marks ADG as complete for status metrics, when `spark-submit` job is complete.  For service dashboard etc, we shouldn't care that anything after this step failed.