### PR TITLE
For incremental use less boxes and a different family which is more a…

### DIFF
--- a/ci/jobs/ami-test/apply-and-test-with-ami.yml
+++ b/ci/jobs/ami-test/apply-and-test-with-ami.yml
@@ -32,10 +32,12 @@ jobs:
             passed:
               - analytical-dataset-generation-qa
           - get: pdm-emr-launcher-release
+            version: { tag: ((pdm-emr-launcher-version.qa)) }
             trigger: false
             passed:
               - analytical-dataset-generation-qa
           - get: emr-relauncher-release
+            version: { tag: ((emr-relauncher-version.qa)) }
             trigger: false
             passed:
               - analytical-dataset-generation-qa

--- a/ci/jobs/analytical-dataset-generation-pr.yml
+++ b/ci/jobs/analytical-dataset-generation-pr.yml
@@ -8,17 +8,19 @@ jobs:
             version: every
           - get: emr-launcher-release
             version: { tag: ((emr-launcher-version.qa)) }
-            trigger: false
+            trigger: true
           - get: pdm-emr-launcher-release
-            trigger: false
+            version: { tag: ((pdm-emr-launcher-version.qa)) }
+            trigger: true
           - get: emr-relauncher-release
-            trigger: false
+            version: { tag: ((emr-relauncher-version.qa)) }
+            trigger: true
           - get: manage-mysql-user-release
-            trigger: false
+            trigger: true
           - get: analytical-dataset-generation-exporter-release
-            trigger: false
+            trigger: true
           - get: al2-emr-ami
-            trigger: false
+            trigger: true
           - get: secrets-management
             trigger: false
       - put: aws-analytical-dataset-generation-pr

--- a/ci/jobs/dev/analytical-dataset-generation-dev.yml
+++ b/ci/jobs/dev/analytical-dataset-generation-dev.yml
@@ -11,8 +11,10 @@ jobs:
             version: { tag: ((emr-launcher-version.development)) }
             trigger: true
           - get: pdm-emr-launcher-release
+            version: { tag: ((pdm-emr-launcher-version.development)) }
             trigger: true
           - get: emr-relauncher-release
+            version: { tag: ((emr-relauncher-version.development)) }
             trigger: true
           - get: analytical-dataset-generation-exporter-release
             trigger: true

--- a/ci/jobs/integration/analytical-dataset-generation-integration.yml
+++ b/ci/jobs/integration/analytical-dataset-generation-integration.yml
@@ -26,10 +26,12 @@ jobs:
             passed:
               - analytical-dataset-generation-qa
           - get: pdm-emr-launcher-release
+            version: { tag: ((pdm-emr-launcher-version.integration)) }
             trigger: true
             passed:
               - analytical-dataset-generation-qa
           - get: emr-relauncher-release
+            version: { tag: ((emr-relauncher-version.integration)) }
             trigger: true
             passed:
               - analytical-dataset-generation-qa

--- a/ci/jobs/preprod/analytical-dataset-generation-preprod.yml
+++ b/ci/jobs/preprod/analytical-dataset-generation-preprod.yml
@@ -24,10 +24,12 @@ jobs:
             passed:
               - analytical-dataset-generation-integration
           - get: pdm-emr-launcher-release
+            version: { tag: ((pdm-emr-launcher-version.preprod)) }
             trigger: true
             passed:
               - analytical-dataset-generation-integration
           - get: emr-relauncher-release
+            version: { tag: ((emr-relauncher-version.preprod)) }
             trigger: true
             passed:
               - analytical-dataset-generation-integration

--- a/ci/jobs/production/admin/clear_dynamodb_row.yml
+++ b/ci/jobs/production/admin/clear_dynamodb_row.yml
@@ -6,5 +6,5 @@ jobs:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.production)):role/ci
             AWS_ACC: ((aws_account.production))
-            CORRELATION_ID: ingest_emr_scheduled_tasks_export_snapshots_to_crown_production_incremental_157_incremental
-            DATA_PRODUCT: ADG-incremental
+            CORRELATION_ID: 071c488d-e920-50dc-b5f6-11c2cb489d9f
+            DATA_PRODUCT: AZKABAN_MONGO_LATEST_EMR_LAUNCHER

--- a/ci/jobs/production/admin/start.yml
+++ b/ci/jobs/production/admin/start.yml
@@ -8,7 +8,7 @@ jobs:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.production)):role/ci
             AWS_ACC: ((aws_account.production))
-            S3_PREFIX: businessdata/mongo/ucdata/2021-04-30/incremental
-            EXPORT_DATE: "2021-04-30"
-            CORRELATION_ID: ingest_emr_scheduled_tasks_export_snapshots_to_crown_production_incremental_157_incremental
+            S3_PREFIX: businessdata/mongo/ucdata/2021-06-25/incremental
+            EXPORT_DATE: "2021-06-25"
+            CORRELATION_ID: 071c488d-e920-50dc-b5f6-11c2cb489d9f
             SNAPSHOT_TYPE: incremental

--- a/ci/jobs/production/analytical-dataset-generation-production.yml
+++ b/ci/jobs/production/analytical-dataset-generation-production.yml
@@ -24,10 +24,12 @@ jobs:
             passed:
               - analytical-dataset-generation-preprod
           - get: pdm-emr-launcher-release
+            version: { tag: ((pdm-emr-launcher-version.production)) }
             trigger: true
             passed:
               - analytical-dataset-generation-preprod
           - get: emr-relauncher-release
+            version: { tag: ((emr-relauncher-version.production)) }
             trigger: true
             passed:
               - analytical-dataset-generation-preprod

--- a/ci/jobs/qa/analytical-dataset-generation-qa.yml
+++ b/ci/jobs/qa/analytical-dataset-generation-qa.yml
@@ -21,8 +21,10 @@ jobs:
             version: { tag: ((emr-launcher-version.qa)) }
             trigger: true
           - get: pdm-emr-launcher-release
+            version: { tag: ((pdm-emr-launcher-version.qa)) }
             trigger: true
           - get: emr-relauncher-release
+            version: { tag: ((emr-relauncher-version.qa)) }
             trigger: true
           - get: analytical-dataset-generation-exporter-release
             trigger: true

--- a/ci/vars.yml
+++ b/ci/vars.yml
@@ -1,6 +1,20 @@
 emr-launcher-version:
-  development: "1.0.33"
-  qa:          "1.0.33"
-  integration: "1.0.33"
-  preprod:     "1.0.33"
-  production:  "1.0.33"
+  development: "1.0.34"
+  qa:          "1.0.34"
+  integration: "1.0.34"
+  preprod:     "1.0.34"
+  production:  "1.0.34"
+
+emr-relauncher-version:
+  development: "0.0.7"
+  qa:          "0.0.7"
+  integration: "0.0.7"
+  preprod:     "0.0.7"
+  production:  "0.0.7"
+
+pdm-emr-launcher-version:
+  development: "0.0.5"
+  qa:          "0.0.5"
+  integration: "0.0.5"
+  preprod:     "0.0.5"
+  production:  "0.0.5"

--- a/cluster_config.tf
+++ b/cluster_config.tf
@@ -49,6 +49,31 @@ resource "aws_s3_bucket_object" "instances" {
   )
 }
 
+resource "aws_s3_bucket_object" "instances_incremental" {
+  bucket = data.terraform_remote_state.common.outputs.config_bucket.id
+  key    = "emr/adg/instances_incremental.yaml"
+  content = templatefile("${path.module}/cluster_config/instances_incremental.yaml.tpl",
+    {
+      keep_cluster_alive = local.keep_cluster_alive[local.environment]
+      add_master_sg      = aws_security_group.adg_common.id
+      add_slave_sg       = aws_security_group.adg_common.id
+      subnet_id = (
+        local.use_capacity_reservation_incremental[local.environment] == true ?
+        data.terraform_remote_state.internal_compute.outputs.adg_subnet_new.subnets[index(data.terraform_remote_state.internal_compute.outputs.adg_subnet_new.subnets.*.availability_zone, data.terraform_remote_state.common.outputs.ec2_capacity_reservations.emr_m5_16_x_large_2a.availability_zone)].id :
+        data.terraform_remote_state.internal_compute.outputs.adg_subnet_new.subnets[index(data.terraform_remote_state.internal_compute.outputs.adg_subnet_new.subnets.*.availability_zone, local.emr_subnet_non_capacity_reserved_environments)].id
+      )
+      master_sg                           = aws_security_group.adg_master.id
+      slave_sg                            = aws_security_group.adg_slave.id
+      service_access_sg                   = aws_security_group.adg_emr_service.id
+      instance_type_core_one              = var.emr_instance_type_core_one_incremental[local.environment]
+      instance_type_master                = var.emr_instance_type_master_incremental[local.environment]
+      core_instance_count                 = var.emr_core_instance_count_incremental[local.environment]
+      capacity_reservation_preference     = local.emr_capacity_reservation_preference_incremental
+      capacity_reservation_usage_strategy = local.emr_capacity_reservation_usage_strategy_incremental
+    }
+  )
+}
+
 resource "aws_s3_bucket_object" "steps" {
   bucket = data.terraform_remote_state.common.outputs.config_bucket.id
   key    = "emr/adg/steps.yaml"

--- a/cluster_config/instances_incremental.yaml.tpl
+++ b/cluster_config/instances_incremental.yaml.tpl
@@ -1,0 +1,50 @@
+---
+Instances:
+  KeepJobFlowAliveWhenNoSteps: ${keep_cluster_alive}
+  AdditionalMasterSecurityGroups:
+  - "${add_master_sg}"
+  AdditionalSlaveSecurityGroups:
+  - "${add_slave_sg}"
+  Ec2SubnetId: "${subnet_id}"
+  EmrManagedMasterSecurityGroup: "${master_sg}"
+  EmrManagedSlaveSecurityGroup: "${slave_sg}"
+  ServiceAccessSecurityGroup: "${service_access_sg}"
+  InstanceFleets:
+  - InstanceFleetType: "MASTER"
+    Name: MASTER
+    TargetOnDemandCapacity: 1
+    %{~ if capacity_reservation_preference == "open" ~}
+    LaunchSpecifications:
+      OnDemandSpecification:
+        AllocationStrategy: "lowest-price"
+        CapacityReservationOptions:
+          CapacityReservationPreference: "${capacity_reservation_preference}"
+          UsageStrategy: "${capacity_reservation_usage_strategy}"
+    %{~ endif ~}
+    InstanceTypeConfigs:
+    - EbsConfiguration:
+        EbsBlockDeviceConfigs:
+        - VolumeSpecification:
+            SizeInGB: 250
+            VolumeType: "gp2"
+          VolumesPerInstance: 1
+      InstanceType: "${instance_type_master}"
+  - InstanceFleetType: "CORE"
+    Name: CORE
+    TargetOnDemandCapacity: ${core_instance_count}
+    %{~ if capacity_reservation_preference == "open" ~}
+    LaunchSpecifications:
+      OnDemandSpecification:
+        AllocationStrategy: "lowest-price"
+        CapacityReservationOptions:
+          CapacityReservationPreference: "${capacity_reservation_preference}"
+          UsageStrategy: "${capacity_reservation_usage_strategy}"
+    %{~ endif ~}
+    InstanceTypeConfigs:
+    - EbsConfiguration:
+        EbsBlockDeviceConfigs:
+        - VolumeSpecification:
+            SizeInGB: 250
+            VolumeType: "gp2"
+          VolumesPerInstance: 1
+      InstanceType: "${instance_type_core_one}"

--- a/local.tf
+++ b/local.tf
@@ -175,7 +175,6 @@ locals {
     production  = false
   }
 
-
   published_db = "analytical_dataset_generation"
 
   hive_metastore_backend = {
@@ -184,14 +183,6 @@ locals {
     integration = "aurora"
     preprod     = "aurora"
     production  = "aurora"
-  }
-
-  hive_metastore_monitoring_interval = {
-    development = 0
-    qa          = 0
-    integration = 0
-    preprod     = 0
-    production  = 0
   }
 
   hive_metastore_enable_perf_insights = {
@@ -284,14 +275,6 @@ locals {
     production  = "5068"
   }
 
-  hive_bytes_per_reducer = {
-    development = "13421728"
-    qa          = "13421728"
-    integration = "13421728"
-    preprod     = "13421728"
-    production  = "13421728"
-  }
-
   tez_runtime_unordered_output_buffer_size_mb = {
     development = "268"
     qa          = "268"
@@ -351,55 +334,6 @@ locals {
     production  = "-Xmx6556m"
   }
 
-  // This value should be the same as yarn.scheduler.maximum-allocation-mb
-  llap_daemon_yarn_container_mb = {
-    development = "57344"
-    qa          = "57344"
-    integration = "57344"
-    preprod     = "385024"
-    production  = "385024"
-  }
-
-  llap_number_of_instances = {
-    development = "5"
-    qa          = "5"
-    integration = "5"
-    preprod     = "20"
-    production  = "20"
-  }
-
-  map_reduce_vcores_per_node = {
-    development = "5"
-    qa          = "5"
-    integration = "5"
-    preprod     = "15"
-    production  = "15"
-  }
-
-  map_reduce_vcores_per_task = {
-    development = "1"
-    qa          = "1"
-    integration = "1"
-    preprod     = "5"
-    production  = "5"
-  }
-
-  hive_max_reducers = {
-    development = "1099"
-    qa          = "1099"
-    integration = "1099"
-    preprod     = "3000"
-    production  = "3000"
-  }
-
-  hive_tez_sessions_per_queue = {
-    development = "10"
-    qa          = "10"
-    integration = "10"
-    preprod     = "35"
-    production  = "35"
-  }
-
   use_capacity_reservation = {
     development = false
     qa          = false
@@ -409,10 +343,20 @@ locals {
   }
 
   emr_capacity_reservation_preference = local.use_capacity_reservation[local.environment] == true ? "open" : "none"
-
   emr_capacity_reservation_usage_strategy = local.use_capacity_reservation[local.environment] == true ? "use-capacity-reservations-first" : ""
 
-  emr_subnet_non_capacity_reserved_environments = "eu-west-2b"
+  use_capacity_reservation_incremental = {
+    development = false
+    qa          = false
+    integration = false
+    preprod     = false
+    production  = false
+  }
+
+  emr_capacity_reservation_preference_incremental = local.use_capacity_reservation_incremental[local.environment] == true ? "open" : "none"
+  emr_capacity_reservation_usage_strategy_incremental = local.use_capacity_reservation_incremental[local.environment] == true ? "use-capacity-reservations-first" : ""
+
+  emr_subnet_non_capacity_reserved_environments = "eu-west-2a"
 
   pdm_start_do_not_run_after_hour = {
     development = "23" # 2300 (UTC) the day after the export as for lower environments we want to run on demand

--- a/local.tf
+++ b/local.tf
@@ -342,7 +342,7 @@ locals {
     production  = true
   }
 
-  emr_capacity_reservation_preference = local.use_capacity_reservation[local.environment] == true ? "open" : "none"
+  emr_capacity_reservation_preference     = local.use_capacity_reservation[local.environment] == true ? "open" : "none"
   emr_capacity_reservation_usage_strategy = local.use_capacity_reservation[local.environment] == true ? "use-capacity-reservations-first" : ""
 
   use_capacity_reservation_incremental = {
@@ -353,7 +353,7 @@ locals {
     production  = false
   }
 
-  emr_capacity_reservation_preference_incremental = local.use_capacity_reservation_incremental[local.environment] == true ? "open" : "none"
+  emr_capacity_reservation_preference_incremental     = local.use_capacity_reservation_incremental[local.environment] == true ? "open" : "none"
   emr_capacity_reservation_usage_strategy_incremental = local.use_capacity_reservation_incremental[local.environment] == true ? "use-capacity-reservations-first" : ""
 
   emr_subnet_non_capacity_reserved_environments = "eu-west-2a"

--- a/variables.tf
+++ b/variables.tf
@@ -82,6 +82,37 @@ variable "emr_core_instance_count" {
   }
 }
 
+variable "emr_instance_type_master_incremental" {
+  default = {
+    development = "r4.2xlarge"
+    qa          = "r4.2xlarge"
+    integration = "r4.2xlarge"
+    preprod     = "r4.8xlarge"
+    production  = "r4.8xlarge"
+  }
+}
+
+variable "emr_instance_type_core_one_incremental" {
+  default = {
+    development = "r4.2xlarge"
+    qa          = "r4.2xlarge"
+    integration = "r4.2xlarge"
+    preprod     = "r4.8xlarge"
+    production  = "r4.8xlarge"
+  }
+}
+
+# Count of instances
+variable "emr_core_instance_count_incremental" {
+  default = {
+    development = "3"
+    qa          = "3"
+    integration = "3"
+    preprod     = "10"
+    production  = "10"
+  }
+}
+
 variable "spark_kyro_buffer" {
   default = {
     development = "128m"


### PR DESCRIPTION
For incremental use less boxes and a different family which is more available in 2a region according to AWS but with same memory profile, also fix some pipeline triggers and extend version vars to all launchers