### PR TITLE
Fix permissions for deleting expired cloudwatch PDM rules

### DIFF
--- a/emr_jobflow_role.tf
+++ b/emr_jobflow_role.tf
@@ -361,6 +361,8 @@ data "aws_iam_policy_document" "adg_cloudwatch_topic_policy_for_pdm_trigger" {
       "events:EnableRule",
       "events:PutRule",
       "events:PutTargets",
+      "events:ListRules",
+      "events:DeleteRule",
     ]
 
     effect = "Allow"


### PR DESCRIPTION
Fix permissions for deleting expired cloudwatch PDM rules