### PR TITLE
adding job to check success with current AMI and using output to exit steps

### DIFF
--- a/ci/jobs/ami-test/apply-and-test-with-ami.yml
+++ b/ci/jobs/ami-test/apply-and-test-with-ami.yml
@@ -48,6 +48,8 @@ jobs:
             resource: untested-al2-emr-ami
             trigger: true
       - .: (( inject meta.plan.check-ami-test-results ))
+        input_mapping:
+          untested_ami: al2-emr-ami
       - .: (( inject meta.plan.terraform-bootstrap ))
         config:
           params:

--- a/ci/jobs/ami-test/apply-and-test-with-ami.yml
+++ b/ci/jobs/ami-test/apply-and-test-with-ami.yml
@@ -7,14 +7,14 @@ jobs:
           - put: meta
             resource: meta-qa
           - get: manage-mysql-user-release
-            trigger: false
+            trigger: true
             params:
               globs:
                 - "*.zip"
             passed:
               - analytical-dataset-generation-qa
           - get: aws-analytical-dataset-generation
-            trigger: false
+            trigger: true
             passed:
               - analytical-dataset-generation-qa
           - get: secrets-management
@@ -27,40 +27,47 @@ jobs:
               - analytical-dataset-generation-qa
           - get: emr-launcher-release
             version: { tag: ((emr-launcher-version.qa)) }
-            trigger: false
+            trigger: true
             passed:
               - analytical-dataset-generation-qa
           - get: pdm-emr-launcher-release
             version: { tag: ((pdm-emr-launcher-version.qa)) }
-            trigger: false
+            trigger: true
             passed:
               - analytical-dataset-generation-qa
           - get: emr-relauncher-release
             version: { tag: ((emr-relauncher-version.qa)) }
-            trigger: false
+            trigger: true
             passed:
               - analytical-dataset-generation-qa
           - get: analytical-dataset-generation-exporter-release
-            trigger: false
+            trigger: true
             passed:
               - analytical-dataset-generation-qa
           - get: al2-emr-ami
             resource: untested-al2-emr-ami
             trigger: true
+      - .: (( inject meta.plan.check-ami-test-results ))
       - .: (( inject meta.plan.terraform-bootstrap ))
         config:
           params:
             AWS_ACC: ((aws_account.qa))
+          inputs:
+            - name: previous_success
       - .: (( inject meta.plan.terraform-apply ))
         config:
           params:
             TF_WORKSPACE: qa
             TEST_AMI_RUN: true
+          inputs:
+            - name: previous_success
       - .: (( inject meta.plan.terraform-plan ))
         config:
           params:
             TF_WORKSPACE: qa
             TEST_AMI_RUN: true
+          inputs:
+            - name: previous_success
       - in_parallel:
         - .: (( inject meta.plan.e2e-tests))
           task: run-full-e2e-tests
@@ -70,6 +77,8 @@ jobs:
               AWS_ACC: ((aws_account.qa))
               AWS_ROLE_ARN: arn:aws:iam::((aws_account.qa)):role/ci
               E2E_FEATURE_TAG_FILTER: "@analytical-dataset-generation-full"
+            inputs:
+              - name: previous_success
         - .: (( inject meta.plan.e2e-tests))
           task: run-incremental-e2e-tests
           config:
@@ -78,6 +87,8 @@ jobs:
               AWS_ACC: ((aws_account.qa))
               AWS_ROLE_ARN: arn:aws:iam::((aws_account.qa)):role/ci
               E2E_FEATURE_TAG_FILTER: "@analytical-dataset-generation-incremental"
+            inputs:
+              - name: previous_success
     on_failure:
       do:
         - .: (( inject meta.plan.ami-test-results ))

--- a/ci/meta.yml
+++ b/ci/meta.yml
@@ -401,7 +401,7 @@ meta:
             - -exc
             - |
               set +x
-              source ../previous_success/exit-if-succeeded.sh
+              source ./previous_success/exit-if-succeeded.sh
 
               AMI_ID=$(cat al2-emr-ami/id)
               DATE=$(date -u)

--- a/ci/meta.yml
+++ b/ci/meta.yml
@@ -25,10 +25,14 @@ meta:
           args:
             - -exc
             - |
+              if [ -f ../previous_success/exit-if-succeeded.sh ]; then
+                source ../previous_success/exit-if-succeeded.sh
+              fi
               python bootstrap_terraform.py
               sed -i '/^assume_role/ d' terraform.tfvars
               cp terraform.tf ../terraform-config
               cp terraform.tfvars ../terraform-config
+              exit 1
           dir: aws-analytical-dataset-generation
         inputs:
           - name: aws-analytical-dataset-generation
@@ -152,6 +156,9 @@ meta:
           args:
             - -exc
             - |
+              if [ -f ../previous_success/exit-if-succeeded.sh ]; then
+                source ../previous_success/exit-if-succeeded.sh
+              fi
               cp ../terraform-config/terraform.tf .
               cp ../terraform-config/terraform.tfvars .
               export TF_VAR_emr_ami_id=$(cat ../al2-emr-ami/id)
@@ -190,6 +197,9 @@ meta:
           args:
             - -exc
             - |
+              if [ -f ../previous_success/exit-if-succeeded.sh ]; then
+                source ../previous_success/exit-if-succeeded.sh
+              fi
               cp ../terraform-config/terraform.tf .
               cp ../terraform-config/terraform.tfvars .
               export TF_VAR_emr_ami_id=$(cat ../al2-emr-ami/id)
@@ -359,6 +369,9 @@ meta:
           args:
             - -exc
             - |
+              if [ -f ../previous_success/exit-if-succeeded.sh ]; then
+                source ../previous_success/exit-if-succeeded.sh
+              fi
               source /assume-role
 
               cd src/runners
@@ -409,3 +422,56 @@ meta:
           - name: meta
           - name: al2-emr-ami
 
+    check-ami-test-results:
+      task: check-ami-test-result
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: ((dataworks.terraform_repository))
+            tag: ((dataworks.terraform_13_version))
+        params:
+          AWS_DEFAULT_REGION: ((dataworks.aws_region))
+          GIT_USERNAME: ((dataworks.concourse_github_username))
+          GIT_EMAIL: ((dataworks.concourse_github_email))
+          GITHUB_TOKEN: ((dataworks-secrets.concourse_github_pat))
+        run:
+          path: sh
+          args:
+            - -exc
+            - |
+              set -x
+
+              PREVIOUS_SUCCESS=false
+              AMI_ID=$(cat al2-emr-ami/id)
+              DATE=$(date -u)
+              PIPELINE="$(cat meta/build_pipeline_name)"
+              PATH_TO_RESULTS="ami-builder-configs/results"
+
+              git config --global user.name "${GIT_USERNAME}"
+              git config --global user.email "${GIT_EMAIL}"
+
+              git clone https://${GITHUB_TOKEN}:x-oauth-basic@github.com/dwp/ami-builder-configs
+
+              if [ -f "./$PATH_TO_RESULTS/$PIPELINE.test" ]; then
+                set +e
+                grep "$AMI_ID SUCCESS" "./$PATH_TO_RESULTS/$PIPELINE.test"
+                if [ $? -eq 0 ]; then
+                  PREVIOUS_SUCCESS=true
+                fi
+                set -e
+              fi
+
+              touch ./previous_success/exit-if-succeeded.sh
+
+              if $PREVIOUS_SUCCESS; then
+                 echo 'echo "AMI already passed. Exiting..."; exit 0' > ./previous_success/exit-if-succeeded.sh
+              fi
+              
+              chmod +x ./previous_success/exit-if-succeeded.sh
+        outputs:
+          - name: previous_success
+        inputs:
+          - name: meta
+          - name: al2-emr-ami

--- a/ci/meta.yml
+++ b/ci/meta.yml
@@ -32,7 +32,6 @@ meta:
               sed -i '/^assume_role/ d' terraform.tfvars
               cp terraform.tf ../terraform-config
               cp terraform.tfvars ../terraform-config
-              exit 1
           dir: aws-analytical-dataset-generation
         inputs:
           - name: aws-analytical-dataset-generation
@@ -402,6 +401,7 @@ meta:
             - -exc
             - |
               set +x
+              source ../previous_success/exit-if-succeeded.sh
 
               AMI_ID=$(cat al2-emr-ami/id)
               DATE=$(date -u)
@@ -421,6 +421,7 @@ meta:
         inputs:
           - name: meta
           - name: al2-emr-ami
+          - name: previous_success
 
     check-ami-test-results:
       task: check-ami-test-result
@@ -441,17 +442,16 @@ meta:
           args:
             - -exc
             - |
-              set -x
+              set +x
 
               PREVIOUS_SUCCESS=false
-              AMI_ID=$(cat al2-emr-ami/id)
+              AMI_ID=$(cat untested_ami/id)
               DATE=$(date -u)
               PIPELINE="$(cat meta/build_pipeline_name)"
               PATH_TO_RESULTS="ami-builder-configs/results"
 
               git config --global user.name "${GIT_USERNAME}"
               git config --global user.email "${GIT_EMAIL}"
-
               git clone https://${GITHUB_TOKEN}:x-oauth-basic@github.com/dwp/ami-builder-configs
 
               if [ -f "./$PATH_TO_RESULTS/$PIPELINE.test" ]; then
@@ -468,10 +468,10 @@ meta:
               if $PREVIOUS_SUCCESS; then
                  echo 'echo "AMI already passed. Exiting..."; exit 0' > ./previous_success/exit-if-succeeded.sh
               fi
-              
+
               chmod +x ./previous_success/exit-if-succeeded.sh
         outputs:
           - name: previous_success
         inputs:
           - name: meta
-          - name: al2-emr-ami
+          - name: untested_ami


### PR DESCRIPTION
* Triggering from same resources as deployment pipeline
* Input for each task
* Source exit script in each task (if input is present)
* Task to check if AMI id already passed the tests

I did it this way as it seems to keep most of the logic in the test job/new task. Seems like the best solution without over complicating it.