### PR TITLE
Reinsert double processing in data tests to ensure tthat overwriting works correctly

### DIFF
--- a/tests/test_generate_dataset_from_htme.py
+++ b/tests/test_generate_dataset_from_htme.py
@@ -500,7 +500,7 @@ def test_create_hive_table_on_published_for_equality(
     actual_json = json.dumps(managed_table_result, default=str)
     print(expected_json)
     print(actual_json)
-    assert len(managed_table_result) == 2
+    assert len(managed_table_result) == 1
 
 @mock_s3
 def test_exception_when_decompression_fails(

--- a/tests/test_generate_dataset_from_htme.py
+++ b/tests/test_generate_dataset_from_htme.py
@@ -423,6 +423,13 @@ def test_create_hive_table_on_published_for_audit_log(
         PUBLISHED_DATABASE_NAME,
         mock_args(),
     )
+    steps.generate_dataset_from_htme.create_hive_table_on_published_for_collection(
+        spark,
+        collection_name,
+        json_location,
+        PUBLISHED_DATABASE_NAME,
+        mock_args(),
+    )
     managed_table = 'auditlog_managed'
     managed_table_raw = 'auditlog_raw'
     tables = spark.catalog.listTables('uc_dw_auditlog')
@@ -473,6 +480,13 @@ def test_create_hive_table_on_published_for_equality(
     collection_name = "data/equality"
     monkeypatch.setattr(steps.generate_dataset_from_htme, "get_equality_managed_file", mock_get_equality_managed_file)
     monkeypatch.setattr(steps.generate_dataset_from_htme, "get_equality_external_file", mock_get_equality_external_file)
+    steps.generate_dataset_from_htme.create_hive_table_on_published_for_collection(
+        spark,
+        collection_name,
+        json_location,
+        PUBLISHED_DATABASE_NAME,
+        mock_args(),
+    )
     steps.generate_dataset_from_htme.create_hive_table_on_published_for_collection(
         spark,
         collection_name,

--- a/tests/test_generate_dataset_from_htme.py
+++ b/tests/test_generate_dataset_from_htme.py
@@ -487,13 +487,6 @@ def test_create_hive_table_on_published_for_equality(
         PUBLISHED_DATABASE_NAME,
         mock_args(),
     )
-    steps.generate_dataset_from_htme.create_hive_table_on_published_for_collection(
-        spark,
-        collection_name,
-        json_location,
-        PUBLISHED_DATABASE_NAME,
-        mock_args(),
-    )
     managed_table = 'equality_managed'
     tables = spark.catalog.listTables('uc_equality')
     actual = list(map(lambda table: table.name, tables))
@@ -507,7 +500,7 @@ def test_create_hive_table_on_published_for_equality(
     actual_json = json.dumps(managed_table_result, default=str)
     print(expected_json)
     print(actual_json)
-    assert len(managed_table_result) == 1
+    assert len(managed_table_result) == 2
 
 @mock_s3
 def test_exception_when_decompression_fails(


### PR DESCRIPTION
Reinsert double processing in data tests to ensure tthat overwriting works correctly