### PR TITLE
Do not schedule ADG in environmnents via the lambda as not used anymore

### DIFF
--- a/emr-launcher.tf
+++ b/emr-launcher.tf
@@ -27,21 +27,9 @@ resource "aws_lambda_function" "adg_emr_launcher" {
     variables = {
       EMR_LAUNCHER_CONFIG_S3_BUCKET = data.terraform_remote_state.common.outputs.config_bucket.id
       EMR_LAUNCHER_CONFIG_S3_FOLDER = "emr/adg"
-      EMR_LAUNCHER_LOG_LEVEL        = "debug"
+      EMR_LAUNCHER_LOG_LEVEL        = local.adg_log_level[local.environment]
     }
   }
-}
-
-resource "aws_cloudwatch_event_rule" "adg_emr_launcher_schedule" {
-  name                = "adg_emr_launcher_schedule"
-  description         = "Triggers ADG EMR Launcher"
-  schedule_expression = format("cron(%s)", local.adg_emr_lambda_schedule[local.environment])
-}
-
-resource "aws_cloudwatch_event_target" "adg_emr_launcher_target" {
-  rule      = aws_cloudwatch_event_rule.adg_emr_launcher_schedule.name
-  target_id = "adg_emr_launcher_target"
-  arn       = aws_lambda_function.adg_emr_launcher.arn
 }
 
 resource "aws_iam_role" "adg_emr_launcher_lambda_role" {

--- a/local.tf
+++ b/local.tf
@@ -48,22 +48,6 @@ locals {
     production  = "dataworks.dwp.gov.uk"
   }
 
-  adg_emr_lambda_schedule = {
-    development = "1 0 * * ? 2099"
-    qa          = "1 0 * * ? *"
-    integration = "00 14 6 Jul ? 2020" # trigger one off temp increase for DW-4437 testing
-    preprod     = "1 0 * * ? *"
-    production  = "1 0 * * ? 2025"
-  }
-
-  pdm_cw_emr_lambda_schedule = {
-    development = "01 12 * * ? 2099"
-    qa          = "00 15 * * ? 2099"
-    integration = "00 15 * * ? 2099"
-    preprod     = "00 15 * * ? 2099"
-    production  = "00 15 * * ? *"
-  }
-
   adg_log_level = {
     development = "DEBUG"
     qa          = "DEBUG"


### PR DESCRIPTION
Do not schedule ADG in environmnents via the lambda as not used anymore